### PR TITLE
Small fix to support ida versions older than 7.6

### DIFF
--- a/gepetto/ida/handlers.py
+++ b/gepetto/ida/handlers.py
@@ -110,8 +110,14 @@ def rename_callback(address, view, response, retries=0):
 
     replaced = []
     for n in names:
-        if ida_hexrays.rename_lvar(function_addr, n, names[n]):
-            replaced.append(n)
+        if idaapi.IDA_SDK_VERSION < 760:
+            lvars = {lvar.name: lvar for lvar in view.cfunc.lvars}
+            if n in lvars:
+                if view.rename_lvar(lvars[n], names[n], True):
+                    replaced.append(n)
+        else:
+            if ida_hexrays.rename_lvar(function_addr, n, names[n]):
+                replaced.append(n)
 
     # Update possible names left in the function comment
     comment = idc.get_func_cmt(address, 0)


### PR DESCRIPTION
IDA versions older than 7.6 do not have the `ida_hexrays.rename_lvar()` available so a workaround is applied in that case.

It might look stupid to "reindex" the lvars on every loop, but the pointers you get are updated after every rename, so ida crashes if you try to use the old pointers.

This should fix #14 and maybe also #21.