### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ variables. Here is a simple example of what results it can provide in mere secon
 Simply drop this script (as well as the `gepetto/` folder) into your IDA plugins folder (`$IDAUSR/plugins`). 
 By default, on Windows, this should be `%AppData%\Hex-Rays\IDA Pro\plugins` (you may need to create the folder).
 
-You will need to add the required packages to IDA's Python installation for the script to work.
-Find which interpreter IDA is using by checking the following registry key: 
-`Computer\HKEY_CURRENT_USER\Software\Hex-Rays\IDA` (default on Windows: `%LOCALAPPDATA%\Programs\Python\Python39`).
-Finally, with the corresponding interpreter, simply run: 
-
+You will need to add the required packages to IDA's Python installation for the script to work.  
+Find which interpreter IDA is using by checking the following registry key:   
+`Computer\HKEY_CURRENT_USER\Software\Hex-Rays\IDA` (default on Windows: `%LOCALAPPDATA%\Programs\Python\Python39`).  
+Once you have placed the files in the plugins directory , open a CMD window and install the requirements
 ```
-[/path/to/python] -m pip install -r requirements.txt
+python -m pip install -r requirements.txt
 ```
 
 ⚠️ You will also need to edit the configuration file (found as `gepetto/config.ini`) and add your own API key, which 


### PR DESCRIPTION
the original instruction about using the interpreter were unclear and confusing to say the least. Why not just open a CMD window and install the requirements while transferring the files in the first place. Installing requirements via IDA will only work 50% of the time and is really a method for advanced users anyways. 90% of the time the IDA python script handler will catch on a new line and fail to resolve the script.

Installing the requirements.txt immediately after placing the file where it belongs is the proper way of doing things. You''ll then open IDA and have a properly working Gepetto plugin , the other method requires restarting IDA.