### PR TITLE
Fix crash when Ollama or LMStudio isn't configured

### DIFF
--- a/gepetto/models/local_lmstudio.py
+++ b/gepetto/models/local_lmstudio.py
@@ -19,7 +19,7 @@ class LMStudio(GPT):
         if LMSTUDIO_MODELS is not None:
             return LMSTUDIO_MODELS
 
-        base_url = gepetto.config.get_config("LMStudio", "BASE_URL", "http://127.0.0.1:1234/v1/")
+        base_url = gepetto.config.get_config("LMStudio", "BASE_URL", default="http://127.0.0.1:1234/v1/")
         try:
             response = _httpx.get(f"{base_url}models", timeout=2)
             if response.status_code == 200:
@@ -44,8 +44,8 @@ class LMStudio(GPT):
             super().__init__(model)
         except ValueError:
             pass
-        
-        base_url = gepetto.config.get_config("LMStudio", "BASE_URL", "http://127.0.0.1:1234/v1/")
+
+        base_url = gepetto.config.get_config("LMStudio", "BASE_URL", default="http://127.0.0.1:1234/v1/")
         proxy = gepetto.config.get_config("Gepetto", "PROXY")
 
         self.model = model

--- a/gepetto/models/local_ollama.py
+++ b/gepetto/models/local_ollama.py
@@ -27,7 +27,7 @@ class Ollama(LanguageModel):
             try:
                 # User a shorter timeout to avoid hanging IDA at startup is the server is unreachable.
                 OLLAMA_MODELS = [m["model"] for m in create_client(timeout=2).list()["models"]]
-            except (_httpx.ConnectError, _httpx.ConnectTimeout, ollama.ResponseError):
+            except (_httpx.ConnectError, _httpx.ConnectTimeout, ollama.ResponseError, ConnectionError):
                 OLLAMA_MODELS = []
         return OLLAMA_MODELS
 


### PR DESCRIPTION
- **Fix LMStudio fallback to default endpoint**

  Pass the default URL to the `default` argument instead of using it as an env var name:

  ```
  Traceback (most recent call last):
  File "<string>", line 2, in ‹module›
  File "/Users/paul/.idapro/plugins/gepetto/config.py", line 31, in load_config load 
  _available_models ()
  File "/Users/paul/. idapro/plugins/gepetto/models/model_manager.py", line 52, in 
  load_available_models spec. loader.exec_module (module)
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module File "<frozen 
  importlib._bootstrap>", line 228, in _call_with.
  _frames_removed
  File "/Users/paul/.idapro/plugins/gepetto/models/local_lmstudio.py", line 79, in 
  <module> gepetto.models.model_manager.register_model(LMStudio)
  ...[snip]...
  File "/Users/paul/Library/Python/3.9/lib/python/site-packages/httpx/_transports/default.py", line 250, in handle_request
  self._pool.handle_request(req)
  resp/Library Developer/CommandL ineTools/Library/Frameworks/Python3. 
  framework/Versions/3.9/1ib/python3.9/contextlib.py", Line 135, in _exit_ rise 
  gers/powltype, ar/ut rae/b/python/site-packages/httpx/_transports/default.py", Line 
  118, in map_httore-exceptions
  raise mapped_exc (message) from exc
  httpx.UnsupportedProtocol:
  Request URL is missing an 'http://' or 'https://' protocol.
  ```

- **Fix Ollama model discovery**

  The whole plugin was crashing if Ollama wasn't running (even if not even used)

  ```
  File "<string>", line 2, in ‹module>
  File "/Users/paul/.idapro/plugins/gepetto/config.py", line 31, in load_config load_available_models ()
  File "/Users/paul/.idapro/plugins/gepetto/models/model_manager.py", line 52, in load_available_models spec. 
  loader.exec_module (module)
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module File "<frozen importlib._bootstrap>", line 228, in 
  _call_with_frames_removed
  File "/Users/paul/.idapro/plugins/gepetto/models/local_ollama.py", line 76, in <module> 
  gepetto.models.model_manager.register_model(0llama)
  File "/Users/paul/.idapro/plugins/gepetto/models/model_manager.py", line 14, in register_model if not 
  model.is_configured_properly():
  File "/Users/paul/.idapro/plugins/gepetto/models/local_ollama.py", line 37, in is_configured_properly return len(Ollama. 
  supported_models ()) > 0
  File "/Users/paul/.idapro/plugins/gepetto/models/local_ollama.py", line 29,
  in supported_models
  OLLAMA _MODELS = [m["model"] for m in create_client (timeout=2). list () ["models"]]
  File "/Users/paul/Library/Python/3.9/lib/python/site-packages/ollama/_client.py", line 567, in list return self._request(
  File "/Users/paul/Library/Python/3.9/lib/python/site-packages/ollama/_client.py", line 178,
  in _request
  return cls**self._request_raw(*args, **kwargs) .json ())
  File "/Users/paul/Library/Python/3.9/lib/python/site-packages/ollama/_client-py", line 124, in_request_raw raise 
  ConnectionError (CONNECTION_ERROR_MESSAGE) from None
  ConnectionError: Failed to connect to Ollama. Please check that Ollama is downloaded, running and accessible. 
  https://ollama.com/download
```