### PR TITLE
Improve translation installation

### DIFF
--- a/gepetto/config.py
+++ b/gepetto/config.py
@@ -2,10 +2,15 @@ import configparser
 import gettext
 import os
 
-from gepetto.models.model_manager import instantiate_model, load_available_models, get_fallback_model
+from gepetto.models.model_manager import (
+    get_fallback_model,
+    instantiate_model,
+    load_available_models,
+)
 
 model = None
 parsed_ini = None
+translate = None   # to hold reference
 
 
 def load_config():
@@ -14,7 +19,7 @@ def load_config():
     Also prepares an OpenAI client configured accordingly to the user specifications.
     :return:
     """
-    global model, parsed_ini
+    global model, parsed_ini, translate
     parsed_ini = configparser.RawConfigParser()
     parsed_ini.read(os.path.join(os.path.abspath(os.path.dirname(__file__)), "config.ini"), encoding="utf-8")
 
@@ -24,7 +29,7 @@ def load_config():
                                     os.path.join(os.path.abspath(os.path.dirname(__file__)), "locales"),
                                     fallback=True,
                                     languages=[language])
-    translate.install("gepetto")  # Install the _() function in the gepetto namespace.
+    translate.install()
 
     # Select model
     requested_model = parsed_ini.get('Gepetto', 'MODEL')


### PR DESCRIPTION
There's actually a very subtle bug in Gepetto. A classic problem with `gettext`'s default behavior in environments where we do not fully control all the code running in the same interpreter, like an embedded Python interpeter in IDA, is that the `_` collides with any plugin or code that uses the `_` in any other piece of code -- a very common pattern across Python programs. The issue stems from `gettext.install()` sticking `_` directly into Python's global namespace. So, if another plugin or piece of code (like in IDA's embedded Python) uses _, it can accidentally overwrite ours.

Secondly, the
[documentation](https://docs.python.org/3/library/gettext.html#gettext.NullTranslations.install) says that the `names` parameter (`install(names=None)`) must be given a `sequence` -- and Python has a wonderful subtle unintuitive behavior where strings are sequences. The [`install(names=None)`](https://github.com/python/cpython/blob/3.13/Lib/gettext.py#L329) method expects a list or tuple. Passing a string like `translate.install("gepetto")` mistakenly sets `_` for each letter `{'g', 'e', 'p', 't', 'o'}`, which definitely isn't what we want.

There are a few ways to handle it, I've started it here but wanted to raise it as a point of discussion. A couple of ways we might handle this:

- Using a distinct global like `_gtr` to avoid any naming clashes.
- Using the translation object directly and skipping global installation altogether.

My approach here is to add `translate` as a global variable to improve visibility in the `load_config` function, as it is now essential to hold the translation reference. 🗣️

Open to feedback on the best approach here!