### PR TITLE
Add AI-assisted function commenting in Hex-Rays pseudocode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Gepetto also provides a CLI interface you can use to ask questions to the LLM di
 The following hotkeys are available:
 
 - Ask the model to explain the function: `Ctrl` + `Alt` + `G`
+- Ask the model to add comments to the code: `Ctrl` + `Alt` + `K`
 - Request better names for the function's variables: `Ctrl` + `Alt` + `R`
 
 Initial testing shows that asking for better names works better if you ask for an explanation of the function first – I

--- a/gepetto/config.ini
+++ b/gepetto/config.ini
@@ -7,6 +7,9 @@ LANGUAGE =
 # Specify a proxy here if you want to route requests via one.
 PROXY =
 
+# Where to place code comments: "above" (before the line/block) or "side" (inline/right).
+COMMENT_POSITION = above
+
 [OpenAI]
 # Set your API key here, or put it in the OPENAI_API_KEY environment variable.
 API_KEY = 

--- a/gepetto/ida/comment_handler.py
+++ b/gepetto/ida/comment_handler.py
@@ -1,0 +1,197 @@
+import functools
+import json
+import re
+import time
+import textwrap
+from urllib import response
+
+import idaapi
+import ida_hexrays
+import ida_kernwin
+import idc
+
+import gepetto.config
+from gepetto.models.model_manager import instantiate_model
+
+_ = gepetto.config._
+
+# -----------------------------------------------------------------------------
+
+class CommentHandler(idaapi.action_handler_t):
+    """
+    This handler queries the model to generate a comment for the
+    selected function. Once the reply is received, it is added
+    as a function comment.
+    """
+
+    def __init__(self):
+        idaapi.action_handler_t.__init__(self)
+
+    def activate(self, ctx):
+        start_time = time.time()
+        decompiler_output = ida_hexrays.decompile(idaapi.get_screen_ea())
+        
+        pseudocode_lines = get_commentable_lines(decompiler_output)
+        formatted_lines = format_commentable_lines(pseudocode_lines)
+        v = ida_hexrays.get_widget_vdui(ctx.widget)
+        gepetto.config.model.query_model_async(
+            _(f"""
+                RESPONSE STRICTLY IN THE FORMAT JSON MAP {{ lineNumber: "comment" }}, NOTHING ELSE!!!
+                Add comments that explain what is happening in this C function.
+                You can ONLY add comments to lines that start with a '+'!
+                DON'T comment trivial or obvious actions; comment on important or non-obvious blocks; read ENTIRE logical blocks before make a comment.
+                \n
+                ```C
+                {formatted_lines}
+                ```
+              """),
+            functools.partial(comment_callback, decompiler_output=decompiler_output, pseudocode_lines=pseudocode_lines, view=v, start_time=start_time),
+            additional_model_options={"response_format": {"type": "json_object"}})
+        print(_("Request to {model} sent...").format(model=str(gepetto.config.model)))
+        return 1
+
+    # This action is always available.
+    def update(self, ctx):
+        return idaapi.AST_ENABLE_ALWAYS
+
+# -----------------------------------------------------------------------------
+
+def comment_callback(decompiler_output, pseudocode_lines, view, response, start_time):
+    """
+    Callback that sets a comment at the given address.
+    :param address: The address of the function to comment
+    :param view: A handle to the decompiler window
+    :param response: The comment to add
+    """
+    try:
+        elapsed_time = time.time() - start_time
+
+        print(f"Response: {response}")
+
+        items = json.loads(response)
+        pairs = [(int(line), comment) for line, comment in items.items()]
+        print(f"Pairs: {pairs}")
+
+        for line, comment in pairs:
+            comment_address = pseudocode_lines[line][2]  # Get the comment address
+            comment_placement = pseudocode_lines[line][3]  # Get the comment placement
+            target = idaapi.treeloc_t()
+            target.ea = comment_address
+            target.itp = comment_placement
+            decompiler_output.set_user_cmt(target, comment)
+
+        decompiler_output.save_user_cmts()
+        decompiler_output.del_orphan_cmts()
+
+        if view:
+            view.refresh_view(True)
+
+        print(_("{model} query finished in {time:.2f} seconds!").format(
+            model=str(gepetto.config.model), time=elapsed_time))
+        
+    except Exception as e:
+        print("[ERROR] comment_callback:", e)
+        raise
+
+
+# -----------------------------------------------------------------------------
+
+def get_commentable_lines(cfunc):
+    """
+    Extracts information for each line of decompiled pseudocode, including:
+      - lineIndex: Line number in the pseudocode listing (starting from 0).
+      - lineText: Cleaned text of the line (IDA formatting tags removed).
+      - comment_address: Address in the decompiled function suitable for attaching a comment, or BADADDR if unavailable.
+      - comment_placement: Comment placement type (e.g., ITP_SEMI, ITP_COLON), or 0 if unavailable.
+      - has_user_comment: True if a user comment already exists for this line, otherwise False.
+
+    Args:
+        cfunc (idaapi.cfuncptr_t): Decompiled function object.
+
+    Returns:
+        List of tuples: (lineIndex, lineText, comment_address, comment_placement, has_user_comment)
+    """
+    result = []
+
+    pseudocode_lines = cfunc.get_pseudocode()
+    
+    place_comments_above = (gepetto.config.get_config("Gepetto", "COMMENT_POSITION", default="above") == "above")
+
+    for idx, line in enumerate(pseudocode_lines):
+        # Clean line text from formatting tags
+        try:
+            line_text = idaapi.tag_remove(line.line)
+        except Exception:
+            line_text = str(line.line)
+
+        # Lookup ctree item
+        phead = idaapi.ctree_item_t()
+        pitem = idaapi.ctree_item_t()
+        ptail = idaapi.ctree_item_t()
+
+        phead_addr = None
+        phead_place = None
+        ptail_addr = None
+        ptail_place = None
+        
+        has_user_comment = False
+        comment_address = None
+        comment_placement = 0
+
+        found = cfunc.get_line_item(line.line, 0, True, phead, pitem, ptail)
+        if found:
+            # Invert preferred locations order
+            if not place_comments_above:
+                tmp = phead
+                phead = ptail
+                ptail = tmp
+                
+            # Assign locations if available and valid
+            if hasattr(phead, "loc") and phead.loc and phead.loc.ea != idaapi.BADADDR:
+                has_user_comment |= (cfunc.get_user_cmt(phead.loc, True) is not None)
+                phead_addr = phead.loc.ea
+                phead_place = phead.loc.itp
+            if hasattr(ptail, "loc") and ptail.loc and ptail.loc.ea != idaapi.BADADDR:
+                has_user_comment |= (cfunc.get_user_cmt(ptail.loc, True) is not None)
+                ptail_addr = ptail.loc.ea
+                ptail_place = ptail.loc.itp
+
+            # Pick final address and placement (prefer phead if present)
+            if phead_addr is not None:
+                comment_address = phead_addr
+                comment_placement = phead_place
+            elif ptail_addr is not None:
+                comment_address = ptail_addr
+                comment_placement = ptail_place
+
+        result.append((idx, idaapi.tag_remove(line_text), comment_address, comment_placement, has_user_comment))
+
+    return result
+
+# -----------------------------------------------------------------------------
+
+def format_commentable_lines(commentable_lines):
+    """
+    Formats the output of get_commentable_lines() for display.
+
+    For each line:
+      - Adds a "+" before the index if a comment address exists and the line does not already have a user comment.
+      - Formats as: [+]index<TAB>text
+
+    Args:
+        commentable_lines: List of tuples (index, text, comment_address, comment_placement, has_user_comment)
+
+    Returns:
+        str: The formatted text as a single string, with one line per entry.
+    """
+    output = []
+    for idx, text, comment_address, comment_placement, has_user_comment in commentable_lines:
+        
+        # Add "+" if the line can be commented and has no user comment yet
+        prefix = "+" if comment_address is not None and not has_user_comment else ""
+        
+        output.append(f"{prefix}{idx}\t{text}")
+    return "\n".join(output)
+
+# -----------------------------------------------------------------------------
+

--- a/gepetto/ida/ui.py
+++ b/gepetto/ida/ui.py
@@ -9,6 +9,7 @@ import ida_kernwin
 
 import gepetto.config
 from gepetto.ida.handlers import ExplainHandler, RenameHandler, SwapModelHandler, GenerateCCodeHandler, GeneratePythonCodeHandler
+from gepetto.ida.comment_handler import CommentHandler
 from gepetto.ida.cli import register_cli
 import gepetto.models.model_manager
 
@@ -23,6 +24,8 @@ class GepettoPlugin(idaapi.plugin_t):
     flags = 0
     explain_action_name = "gepetto:explain_function"
     explain_menu_path = "Edit/Gepetto/" + _("Explain function")
+    comment_action_name = "gepetto:comment_function"
+    comment_menu_path = "Edit/Gepetto/" + _("Comment function")
     rename_action_name = "gepetto:rename_function"
     rename_menu_path = "Edit/Gepetto/" + _("Rename variables")
     c_code_action_name = "gepetto:generate_c_code"
@@ -55,6 +58,16 @@ class GepettoPlugin(idaapi.plugin_t):
                                                   model=str(gepetto.config.model)),
                                               452)
         idaapi.register_action(explain_action)
+
+        # Function commenting action
+        comment_action = idaapi.action_desc_t(self.comment_action_name,
+                                              _('Comment function'),
+                                              CommentHandler(),
+                                              "Ctrl+Alt+K",
+                                              _('Use {model} to add a comment to the currently selected function').format(
+                                                  model=str(gepetto.config.model)),
+                                              453)
+        idaapi.register_action(comment_action)
 
         # Variable renaming action
         rename_action = idaapi.action_desc_t(self.rename_action_name,
@@ -93,6 +106,7 @@ class GepettoPlugin(idaapi.plugin_t):
         idaapi.register_action(generate_c_code_action)
 
         idaapi.attach_action_to_menu(self.explain_menu_path, self.explain_action_name, idaapi.SETMENU_APP)
+        idaapi.attach_action_to_menu(self.comment_menu_path, self.comment_action_name, idaapi.SETMENU_APP)
         idaapi.attach_action_to_menu(self.rename_menu_path, self.rename_action_name, idaapi.SETMENU_APP)
         idaapi.attach_action_to_menu(self.c_code_menu_path, self.c_code_action_name, idaapi.SETMENU_APP)
         idaapi.attach_action_to_menu(self.python_code_menu_path, self.python_code_action_name, idaapi.SETMENU_APP)
@@ -184,6 +198,7 @@ class ContextMenuHooks(idaapi.UI_Hooks):
         # Add actions to the context menu of the Pseudocode view
         if idaapi.get_widget_type(form) == idaapi.BWN_PSEUDOCODE:
             idaapi.attach_action_to_popup(form, popup, GepettoPlugin.explain_action_name, "Gepetto/")
+            idaapi.attach_action_to_popup(form, popup, GepettoPlugin.comment_action_name, "Gepetto/")
             idaapi.attach_action_to_popup(form, popup, GepettoPlugin.rename_action_name, "Gepetto/")
             idaapi.attach_action_to_popup(form, popup, GepettoPlugin.c_code_action_name, "Gepetto/")
             idaapi.attach_action_to_popup(form, popup, GepettoPlugin.python_code_action_name, "Gepetto/")


### PR DESCRIPTION
This PR introduces a new feature that uses AI to automatically generate comments for C functions in Hex-Rays decompiler output.

* Added a new action that queries an LLM for comments on non-trivial code blocks.
* Comments are added directly into the pseudocode, only for lines that can actually be commented (has real address).
* Supports configuration for placing comments `above` or to the `right` of code lines (in `config.ini`).

The logic is similar to Explain - select a function, run the command, and try not to change the code while you wait for the result.
As with Rename Variables, does not support undo. :(

It might make sense to tweak the query to model, as it currently GPT-4.1 comments VERY aggressively, literally on every line. >_>

<img width="2308" height="732" alt="image" src="https://github.com/user-attachments/assets/d116767d-4042-4a90-b2e6-94be96923528" />
