### PR TITLE
Add auto-rename action and function renaming

### DIFF
--- a/gepetto/ida/ui.py
+++ b/gepetto/ida/ui.py
@@ -28,7 +28,7 @@ class GepettoPlugin(idaapi.plugin_t):
     comment_action_name = "gepetto:comment_function"
     comment_menu_path = "Edit/Gepetto/" + _("Comment function")
     rename_action_name = "gepetto:rename_function"
-    rename_menu_path = "Edit/Gepetto/" + _("Rename variables")
+    rename_menu_path = "Edit/Gepetto/" + _("Auto-rename")
     c_code_action_name = "gepetto:generate_c_code"
     c_code_menu_path = "Edit/Gepetto/" + _("Generate C Code")
     python_code_action_name = "gepetto:generate_python_code"
@@ -73,12 +73,12 @@ class GepettoPlugin(idaapi.plugin_t):
                                               453)
         idaapi.register_action(comment_action)
 
-        # Variable renaming action
+        # Variable and function renaming action
         rename_action = idaapi.action_desc_t(self.rename_action_name,
-                                             _('Rename variables'),
+                                             _('Auto-rename'),
                                              RenameHandler(),
                                              "Ctrl+Alt+R",
-                                             _("Use {model} to rename this function's variables").format(
+                                             _("Use {model} to auto-rename this function and its variables").format(
                                                  model=str(gepetto.config.model)),
                                              19)
         idaapi.register_action(rename_action)

--- a/gepetto/locales/ca_ES/LC_MESSAGES/gepetto.po
+++ b/gepetto/locales/ca_ES/LC_MESSAGES/gepetto.po
@@ -139,8 +139,8 @@ msgid "Comment function"
 msgstr "Explicar la funció"
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
-msgstr "Reanomenar les variables"
+msgid "Auto-rename"
+msgstr "Reanomenar automàticament"
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
 msgid "Generate C Code"
@@ -171,8 +171,8 @@ msgstr "Adds comments to lines in the current function using {model}"
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
-msgstr "Utilitzar {model} per reanomenar les variables d'aquesta funció"
+msgid "Use {model} to auto-rename this function and its variables"
+msgstr "Utilitzar {model} per reanomenar automàticament aquesta funció i les seves variables"
 
 #: gepetto/ida/ui.py:92
 #, fuzzy, python-brace-format
@@ -204,6 +204,11 @@ msgstr ""
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
 msgstr "Conversación de LLM"
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
+msgstr "Fet! S'han reanomenat {count} nom(s)."
 
 #~ msgid ""
 #~ "Could not obtain valid data from the model, giving up. Dumping the response "

--- a/gepetto/locales/es_ES/LC_MESSAGES/gepetto.po
+++ b/gepetto/locales/es_ES/LC_MESSAGES/gepetto.po
@@ -138,8 +138,8 @@ msgid "Comment function"
 msgstr "Explicar la función"
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
-msgstr "Renombrar las variables"
+msgid "Auto-rename"
+msgstr "Renombrado automático"
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
 msgid "Generate C Code"
@@ -170,8 +170,8 @@ msgstr "Adds comments to lines in the current function using {model}"
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
-msgstr "Usar {model} para renombrar las variables de esta función"
+msgid "Use {model} to auto-rename this function and its variables"
+msgstr "Usar {model} para renombrar automáticamente esta función y sus variables"
 
 #: gepetto/ida/ui.py:92
 #, fuzzy, python-brace-format
@@ -203,6 +203,11 @@ msgstr ""
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
 msgstr "Conversación de LLM"
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
+msgstr "¡Hecho! Se ha(n) renombrado {count} nombre(s)."
 
 #~ msgid ""
 #~ "Could not obtain valid data from the model, giving up. Dumping the response "

--- a/gepetto/locales/fr_FR/LC_MESSAGES/gepetto.po
+++ b/gepetto/locales/fr_FR/LC_MESSAGES/gepetto.po
@@ -139,8 +139,8 @@ msgid "Comment function"
 msgstr "Expliquer la fonction"
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
-msgstr "Renommer les variables"
+msgid "Auto-rename"
+msgstr "Renommage automatique"
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
 msgid "Generate C Code"
@@ -171,8 +171,8 @@ msgstr "Adds comments to lines in the current function using {model}"
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
-msgstr "Utiliser {model} pour renommer les variables de cette fonction"
+msgid "Use {model} to auto-rename this function and its variables"
+msgstr "Utiliser {model} pour renommer automatiquement cette fonction et ses variables"
 
 #: gepetto/ida/ui.py:92
 #, fuzzy, python-brace-format
@@ -204,6 +204,11 @@ msgstr ""
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
 msgstr "Conversation avec le LLM"
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
+msgstr "Terminé ! {count} nom(s) renommé(s)."
 
 #~ msgid ""
 #~ "Could not obtain valid data from the model, giving up. Dumping the response "

--- a/gepetto/locales/gepetto.pot
+++ b/gepetto/locales/gepetto.pot
@@ -122,7 +122,7 @@ msgid "Comment function"
 msgstr ""
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
+msgid "Auto-rename"
 msgstr ""
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
@@ -154,7 +154,7 @@ msgstr ""
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
+msgid "Use {model} to auto-rename this function and its variables"
 msgstr ""
 
 #: gepetto/ida/ui.py:92
@@ -180,4 +180,9 @@ msgstr ""
 
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
+msgstr ""
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
 msgstr ""

--- a/gepetto/locales/it_IT/LC_MESSAGES/gepetto.po
+++ b/gepetto/locales/it_IT/LC_MESSAGES/gepetto.po
@@ -135,8 +135,8 @@ msgid "Comment function"
 msgstr "Descrivi la funzione"
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
-msgstr "Rinomina le variabili"
+msgid "Auto-rename"
+msgstr "Rinominazione automatica"
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
 msgid "Generate C Code"
@@ -167,8 +167,8 @@ msgstr "Adds comments to lines in the current function using {model}"
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
-msgstr "Usa {model} per rinominare le variabili di questa funzione"
+msgid "Use {model} to auto-rename this function and its variables"
+msgstr "Usa {model} per rinominare automaticamente questa funzione e le sue variabili"
 
 #: gepetto/ida/ui.py:92
 #, fuzzy, python-brace-format
@@ -200,6 +200,11 @@ msgstr ""
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
 msgstr "Conversazione LLM"
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
+msgstr "Fatto! Rinominati {count} nome(i)."
 
 #~ msgid ""
 #~ "Could not obtain valid data from the model, giving up. Dumping the response "

--- a/gepetto/locales/ko_KR/LC_MESSAGES/gepetto.po
+++ b/gepetto/locales/ko_KR/LC_MESSAGES/gepetto.po
@@ -130,8 +130,8 @@ msgid "Comment function"
 msgstr "함수 설명"
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
-msgstr "변수 이름 변경"
+msgid "Auto-rename"
+msgstr "자동 이름 바꾸기"
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
 msgid "Generate C Code"
@@ -162,8 +162,8 @@ msgstr "Adds comments to lines in the current function using {model}"
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
-msgstr "{model}을(를) 사용하여 이 함수의 변수 이름을 변경합니다"
+msgid "Use {model} to auto-rename this function and its variables"
+msgstr "{model}을(를) 사용하여 이 함수와 그 변수의 이름을 자동으로 바꿉니다"
 
 #: gepetto/ida/ui.py:92
 #, fuzzy, python-brace-format
@@ -194,6 +194,11 @@ msgstr ""
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
 msgstr "LLM 대화"
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
+msgstr "완료! {count}개의 이름이 변경되었습니다."
 
 #~ msgid ""
 #~ "Could not obtain valid data from the model, giving up. Dumping the response "

--- a/gepetto/locales/ru/LC_MESSAGES/gepetto.po
+++ b/gepetto/locales/ru/LC_MESSAGES/gepetto.po
@@ -137,8 +137,8 @@ msgid "Comment function"
 msgstr "Комментировать функцию"
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
-msgstr "Переименовать переменные"
+msgid "Auto-rename"
+msgstr "Автопереименование"
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
 msgid "Generate C Code"
@@ -169,8 +169,8 @@ msgstr "Добавляет комментарии к строкам текуще
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
-msgstr "Используйте {model} для переименования переменных этой функции"
+msgid "Use {model} to auto-rename this function and its variables"
+msgstr "Используйте {model} для автоматического переименования этой функции и её переменных"
 
 #: gepetto/ida/ui.py:92
 #, fuzzy, python-brace-format
@@ -200,6 +200,11 @@ msgstr ""
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
 msgstr "Чат LLM"
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
+msgstr "Готово! Переименовано {count} имён."
 
 #~ msgid ""
 #~ "Could not obtain valid data from the model, giving up. Dumping the response "

--- a/gepetto/locales/tr/LC_MESSAGES/gepetto.po
+++ b/gepetto/locales/tr/LC_MESSAGES/gepetto.po
@@ -137,8 +137,8 @@ msgid "Comment function"
 msgstr "işlevi açıkla"
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
-msgstr "Değişkenleri yeniden adlandırın"
+msgid "Auto-rename"
+msgstr "Otomatik yeniden adlandırma"
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
 msgid "Generate C Code"
@@ -169,9 +169,8 @@ msgstr "Adds comments to lines in the current function using {model}"
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
-msgstr ""
-"Bu fonksiyonun değişkenlerini yeniden adlandırmak için {model} kullanın"
+msgid "Use {model} to auto-rename this function and its variables"
+msgstr "Bu fonksiyonu ve değişkenlerini otomatik olarak yeniden adlandırmak için {model} kullanın"
 
 #: gepetto/ida/ui.py:92
 #, fuzzy, python-brace-format
@@ -203,6 +202,11 @@ msgstr ""
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
 msgstr "LLM sohbet"
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
+msgstr "Bitti! {count} ad yeniden adlandırıldı."
 
 #~ msgid ""
 #~ "Could not obtain valid data from the model, giving up. Dumping the response "

--- a/gepetto/locales/zh_CN/LC_MESSAGES/gepetto.po
+++ b/gepetto/locales/zh_CN/LC_MESSAGES/gepetto.po
@@ -130,8 +130,8 @@ msgid "Comment function"
 msgstr "解释函数"
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
-msgstr "重命名变量"
+msgid "Auto-rename"
+msgstr "自动重命名"
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
 msgid "Generate C Code"
@@ -162,8 +162,8 @@ msgstr "使用 {model} 从当前选择的函数生成 python 代码"
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
-msgstr "使用 {model} 重命名函数的变量"
+msgid "Use {model} to auto-rename this function and its variables"
+msgstr "使用 {model} 自动重命名此函数及其变量"
 
 #: gepetto/ida/ui.py:92
 #, python-brace-format
@@ -191,6 +191,11 @@ msgstr "您是内置于 IDA Pro 的智能助手，主要职责是协助逆向工
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
 msgstr "LLM 对话"
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
+msgstr "完成！已重命名 {count} 个名称。"
 
 #~ msgid ""
 #~ "Could not obtain valid data from the model, giving up. Dumping the response "

--- a/gepetto/locales/zh_TW/LC_MESSAGES/gepetto.po
+++ b/gepetto/locales/zh_TW/LC_MESSAGES/gepetto.po
@@ -130,8 +130,8 @@ msgid "Comment function"
 msgstr "解釋函數"
 
 #: gepetto/ida/ui.py:31 gepetto/ida/ui.py:78
-msgid "Rename variables"
-msgstr "重新命名變數"
+msgid "Auto-rename"
+msgstr "自動重新命名"
 
 #: gepetto/ida/ui.py:33 gepetto/ida/ui.py:102
 msgid "Generate C Code"
@@ -162,8 +162,8 @@ msgstr "Adds comments to lines in the current function using {model}"
 
 #: gepetto/ida/ui.py:81
 #, python-brace-format
-msgid "Use {model} to rename this function's variables"
-msgstr "使用 {model} 來重命名這個函數中的變數"
+msgid "Use {model} to auto-rename this function and its variables"
+msgstr "使用 {model} 自動重新命名此函式及其變數"
 
 #: gepetto/ida/ui.py:92
 #, fuzzy, python-brace-format
@@ -193,6 +193,11 @@ msgstr "你是嵌入在 IDA Pro 中的有用助手。你的角色是促進逆向
 #: gepetto/ida/cli.py:19
 msgid "LLM chat"
 msgstr "LLM 對話"
+
+#: gepetto/ida/handlers.py:178
+#, python-brace-format
+msgid "Done! {count} name(s) renamed."
+msgstr "完成！已重新命名 {count} 個名稱。"
 
 #~ msgid ""
 #~ "Could not obtain valid data from the model, giving up. Dumping the response "


### PR DESCRIPTION
Rename plugin action to Auto-rename and include function renaming.
Refine renaming prompt to skip unchanged names unless improved.
Sync translations