### PR TITLE
Add cross-reference retrieval tool

### DIFF
--- a/gepetto/ida/cli.py
+++ b/gepetto/ida/cli.py
@@ -12,6 +12,7 @@ import gepetto.ida.tools.get_screen_ea
 import gepetto.ida.tools.get_function_code
 import gepetto.ida.tools.rename_lvar
 import gepetto.ida.tools.rename_function
+import gepetto.ida.tools.get_xrefs
 
 _ = gepetto.config._
 CLI: ida_kernwin.cli_t = None
@@ -71,6 +72,8 @@ class GepettoCLI(ida_kernwin.cli_t):
                         gepetto.ida.tools.rename_lvar.handle_rename_lvar_tc(tc, MESSAGES)
                     elif tc.function.name == "rename_function":
                         gepetto.ida.tools.rename_function.handle_rename_function_tc(tc, MESSAGES)
+                    elif tc.function.name == "get_xrefs":
+                        gepetto.ida.tools.get_xrefs.handle_get_xrefs_tc(tc, MESSAGES)
                 stream_and_handle()
             else:
                 MESSAGES.append({"role": "assistant", "content": response.content or ""})

--- a/gepetto/ida/tools/get_xrefs.py
+++ b/gepetto/ida/tools/get_xrefs.py
@@ -1,0 +1,74 @@
+import json
+
+import ida_kernwin
+import ida_xref
+
+from .function_utils import parse_ea as _parse_ea
+
+
+
+def handle_get_xrefs_tc(tc, messages):
+    """Handle a tool call to gather cross-references."""
+    try:
+        args = json.loads(tc.function.arguments or "{}")
+    except Exception:
+        args = {}
+
+    ea = args.get("ea")
+    if ea is not None:
+        ea = _parse_ea(ea)
+    direction = args.get("direction", "from")
+
+    try:
+        result = get_xrefs(ea=ea, direction=direction)
+    except Exception as ex:
+        result = {
+            "ok": False,
+            "ea": ea,
+            "direction": direction,
+            "error": str(ex),
+            "xrefs": [],
+        }
+
+    messages.append(
+        {
+            "role": "tool",
+            "tool_call_id": tc.id,
+            "content": json.dumps(result, ensure_ascii=False),
+        }
+    )
+
+
+# -----------------------------------------------------------------------------
+
+
+def get_xrefs(ea: int, direction: str) -> dict:
+    """Collect cross-references to or from an address.
+
+    Args:
+        ea: Effective address to inspect.
+        direction: 'to' for incoming, 'from' for outgoing references.
+    """
+    if ea is None:
+        raise ValueError("ea is required")
+    if direction not in ("to", "from"):
+        raise ValueError("direction must be 'to' or 'from'")
+
+    xrefs: list[int] = []
+
+    def _do():
+        if direction == "to":
+            xr = ida_xref.get_first_xref_to(ea)
+            while xr:
+                xrefs.append(int(xr.frm))
+                xr = ida_xref.get_next_xref_to(ea, xr)
+        else:
+            xr = ida_xref.get_first_xref_from(ea)
+            while xr:
+                xrefs.append(int(xr.to))
+                xr = ida_xref.get_next_xref_from(ea, xr)
+        return 1
+
+    ida_kernwin.execute_sync(_do, ida_kernwin.MFF_FAST)
+
+    return {"ok": True, "ea": ea, "direction": direction, "xrefs": xrefs}

--- a/gepetto/ida/tools/tools.py
+++ b/gepetto/ida/tools/tools.py
@@ -84,4 +84,25 @@ TOOLS = [
             },
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_xrefs",
+            "description": "Return cross-references to or from an address.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "ea": {
+                        "type": "integer",
+                        "description": "Effective address (EA) to inspect, in decimal or hex.",
+                    },
+                    "direction": {
+                        "type": "string",
+                        "enum": ["to", "from"],
+                        "description": "Direction of cross-references: 'to' for incoming, 'from' for outgoing.",
+                    },
+                },
+            },
+        },
+    },
 ]


### PR DESCRIPTION
## Summary
- Add `get_xrefs` tool to enumerate xrefs to or from a given EA
- Register `get_xrefs` in tool list and CLI dispatch

## Testing
- `pytest -q`
- `python -m tests.unit -q` *(fails: ModuleNotFoundError: ida_kernwin)*

------
https://chatgpt.com/codex/tasks/task_e_68b037e42bc48323b17eebcad146a473