### PR TITLE
Add get_ea tool for resolving symbol addresses

### DIFF
--- a/gepetto/ida/cli.py
+++ b/gepetto/ida/cli.py
@@ -10,6 +10,7 @@ import gepetto.ida.handlers
 from gepetto.ida.tools.tools import TOOLS
 import gepetto.ida.tools.cast
 import gepetto.ida.tools.call_graph
+import gepetto.ida.tools.get_ea
 import gepetto.ida.tools.get_function_code
 import gepetto.ida.tools.get_screen_ea
 import gepetto.ida.tools.get_xrefs
@@ -72,6 +73,8 @@ class GepettoCLI(ida_kernwin.cli_t):
                 for tc in response.tool_calls:
                     if tc.function.name == "get_screen_ea":
                         gepetto.ida.tools.get_screen_ea.handle_get_screen_ea_tc(tc, MESSAGES)
+                    elif tc.function.name == "get_ea":
+                        gepetto.ida.tools.get_ea.handle_get_ea_tc(tc, MESSAGES)
                     elif tc.function.name == "get_function_code":
                         gepetto.ida.tools.get_function_code.handle_get_function_code_tc(tc, MESSAGES)
                     elif tc.function.name == "rename_lvar":

--- a/gepetto/ida/tools/get_ea.py
+++ b/gepetto/ida/tools/get_ea.py
@@ -1,0 +1,26 @@
+import json
+
+from gepetto.ida.tools.function_utils import resolve_ea
+from gepetto.ida.tools.tools import add_result_to_messages
+
+
+def handle_get_ea_tc(tc, messages):
+    try:
+        args = json.loads(tc.function.arguments or "{}")
+    except Exception:
+        args = {}
+
+    name = args.get("name")
+
+    try:
+        ea = get_ea(name)
+        payload = {"ok": True, "ea": ea}
+    except Exception as ex:
+        payload = {"ok": False, "error": str(ex)}
+
+    add_result_to_messages(messages, tc, payload)
+
+
+def get_ea(name: str) -> int:
+    """Return the effective address for a symbol name."""
+    return resolve_ea(name)

--- a/gepetto/ida/tools/tools.py
+++ b/gepetto/ida/tools/tools.py
@@ -17,6 +17,23 @@ TOOLS = [
     {
         "type": "function",
         "function": {
+            "name": "get_ea",
+            "description": "Return EA for a symbol name.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Symbol or function name.",
+                    },
+                },
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "get_function_code",
             "description": "Return Hex-Rays pseudocode for a function, resolved by EA or by name.",
             "parameters": {


### PR DESCRIPTION
## Summary
- add `get_ea` tool that resolves a symbol name to its effective address
- register `get_ea` tool and dispatch requests through CLI

## Testing
- `python -m unittest tests.unit -v` *(fails: No model available. Please edit the configuration file and try again.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ee914b1483238edee632bd9dca30