### PR TITLE
Add decimal to hex conversion tool

### DIFF
--- a/gepetto/ida/cli.py
+++ b/gepetto/ida/cli.py
@@ -18,6 +18,7 @@ import gepetto.ida.tools.list_symbols
 import gepetto.ida.tools.refresh_view
 import gepetto.ida.tools.rename_lvar
 import gepetto.ida.tools.rename_function
+import gepetto.ida.tools.to_hex
 
 _ = gepetto.config._
 CLI: ida_kernwin.cli_t = None
@@ -34,7 +35,8 @@ MESSAGES: list[dict] = [
             f"current EA. \"This\" function or the \"current\" function always mean the one at the current EA.\n"
             f"When asked to perform an operation (such as renaming something), don't ask for confirmation. Just do it!\n"
             f"Always refresh the disassembly view after making a change in the IDB (renaming, etc.), so it is shown to"
-            f"the user (no need to mention when you do it).",
+            f"the user (no need to mention when you do it).\n"
+            f"Never convert decimal numbers to hexadecimal yourself; always use the `to_hex` tool for that.",
     }
 ]  # Keep a history of the conversation to simulate LLM memory.
 
@@ -86,6 +88,8 @@ class GepettoCLI(ida_kernwin.cli_t):
                         gepetto.ida.tools.get_xrefs.handle_get_xrefs_tc(tc, MESSAGES)
                     elif tc.function.name == "list_symbols":
                         gepetto.ida.tools.list_symbols.handle_list_symbols_tc(tc, MESSAGES)
+                    elif tc.function.name == "to_hex":
+                        gepetto.ida.tools.to_hex.handle_to_hex_tc(tc, MESSAGES)
                     elif tc.function.name == "get_callers":
                         gepetto.ida.tools.call_graph.handle_get_callers_tc(tc, MESSAGES)
                     elif tc.function.name == "get_callees":

--- a/gepetto/ida/tools/to_hex.py
+++ b/gepetto/ida/tools/to_hex.py
@@ -1,0 +1,29 @@
+"""Tool to convert decimal integers to hexadecimal strings."""
+
+import json
+
+from gepetto.ida.tools.tools import add_result_to_messages
+
+
+def handle_to_hex_tc(tc, messages):
+    """Handle a `to_hex` tool call."""
+    try:
+        args = json.loads(tc.function.arguments or "{}")
+    except Exception:
+        args = {}
+
+    value = args.get("value")
+
+    try:
+        hex_value = to_hex(value)
+        payload = {"ok": True, "hex": hex_value}
+    except Exception as ex:
+        payload = {"ok": False, "error": str(ex)}
+
+    add_result_to_messages(messages, tc, payload)
+
+
+def to_hex(value) -> str:
+    """Return the hexadecimal string for a decimal integer."""
+    return hex(int(value))
+

--- a/gepetto/ida/tools/tools.py
+++ b/gepetto/ida/tools/tools.py
@@ -34,6 +34,23 @@ TOOLS = [
     {
         "type": "function",
         "function": {
+            "name": "to_hex",
+            "description": "Convert a decimal integer to a hexadecimal string.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "description": "Decimal integer to convert.",
+                    },
+                },
+                "required": ["value"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "get_function_code",
             "description": "Return Hex-Rays pseudocode for a function, resolved by EA or by name.",
             "parameters": {


### PR DESCRIPTION
## Summary
- add `to_hex` tool that converts decimal integers to hex strings
- register `to_hex` and update CLI to dispatch it
- instruct the model in CLI prompt to always use `to_hex`

## Testing
- `pytest -q`
- `PYTHONPATH=. python tests/unit.py -q` *(fails: No model available / missing IDA modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ec8e3a1c8323850f9778a2bb4655