### PR TITLE
Add search tool for text and hex pattern lookups

### DIFF
--- a/gepetto/ida/cli.py
+++ b/gepetto/ida/cli.py
@@ -18,6 +18,7 @@ import gepetto.ida.tools.list_symbols
 import gepetto.ida.tools.refresh_view
 import gepetto.ida.tools.rename_lvar
 import gepetto.ida.tools.rename_function
+import gepetto.ida.tools.search
 
 _ = gepetto.config._
 CLI: ida_kernwin.cli_t = None
@@ -86,6 +87,8 @@ class GepettoCLI(ida_kernwin.cli_t):
                         gepetto.ida.tools.get_xrefs.handle_get_xrefs_tc(tc, MESSAGES)
                     elif tc.function.name == "list_symbols":
                         gepetto.ida.tools.list_symbols.handle_list_symbols_tc(tc, MESSAGES)
+                    elif tc.function.name == "search":
+                        gepetto.ida.tools.search.handle_search_tc(tc, MESSAGES)
                     elif tc.function.name == "get_callers":
                         gepetto.ida.tools.call_graph.handle_get_callers_tc(tc, MESSAGES)
                     elif tc.function.name == "get_callees":

--- a/gepetto/ida/tools/search.py
+++ b/gepetto/ida/tools/search.py
@@ -1,0 +1,71 @@
+import json
+
+import ida_bytes
+import ida_search
+import ida_kernwin
+import ida_idaapi
+
+from gepetto.ida.tools.tools import add_result_to_messages
+
+
+def handle_search_tc(tc, messages):
+    try:
+        args = json.loads(getattr(tc.function, "arguments", "") or "{}")
+    except Exception:
+        args = {}
+
+    text = args.get("text")
+    hex_pattern = args.get("hex")
+    case_sensitive = bool(args.get("case_sensitive", False))
+
+    try:
+        result = search(text=text, hex=hex_pattern, case_sensitive=case_sensitive)
+    except Exception as ex:
+        result = {"ok": False, "error": str(ex)}
+
+    add_result_to_messages(messages, tc, result)
+
+
+def search(text: str | None = None, hex: str | None = None, case_sensitive: bool = False) -> dict:
+    out: dict = {"ok": False, "eas": [], "error": None}
+
+    if not text and not hex:
+        out["error"] = "Either text or hex must be provided"
+        return out
+
+    def _do():
+        try:
+            matches: list[int] = []
+            if text:
+                cmp_text = text if case_sensitive else text.lower()
+                try:
+                    flags = getattr(ida_bytes, "STRFIND_CASE", 0) if case_sensitive else 0
+                    ea = ida_bytes.find_strlit(0, cmp_text, flags)
+                    while ea != ida_idaapi.BADADDR:
+                        matches.append(int(ea))
+                        ea = ida_bytes.find_strlit(ea + 1, cmp_text, flags)
+                except Exception:
+                    f = ida_search.SEARCH_DOWN
+                    if case_sensitive:
+                        f |= ida_search.SEARCH_CASE
+                    ea = ida_search.find_text(0, 1, 1, text, f)
+                    while ea != ida_idaapi.BADADDR:
+                        matches.append(int(ea))
+                        ea = ida_search.find_text(ea + 1, 1, 1, text, f)
+
+            if hex:
+                f = ida_search.SEARCH_DOWN
+                ea = ida_search.find_binary(0, ida_idaapi.BADADDR, hex, 16, f)
+                while ea != ida_idaapi.BADADDR:
+                    matches.append(int(ea))
+                    ea = ida_search.find_binary(ea + 1, ida_idaapi.BADADDR, hex, 16, f)
+
+            out["eas"] = matches
+            out["ok"] = True
+            return 1
+        except Exception as e:
+            out["error"] = str(e)
+            return 0
+
+    ida_kernwin.execute_sync(_do, ida_kernwin.MFF_READ)
+    return out

--- a/gepetto/ida/tools/tools.py
+++ b/gepetto/ida/tools/tools.py
@@ -213,6 +213,32 @@ TOOLS = [
     {
         "type": "function",
         "function": {
+            "name": "search",
+            "description": "Search for text strings or hex byte patterns and return matching EAs.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string",
+                        "description": "ASCII text to look for.",
+                    },
+                    "hex": {
+                        "type": "string",
+                        "description": "Hex pattern like '90 90 ?? FF'.",
+                    },
+                    "case_sensitive": {
+                        "type": "boolean",
+                        "description": "Case-sensitive text search.",
+                        "default": False,
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "get_callers",
             "description": "Return the unique caller functions of a target function (by EA or name).",
             "parameters": {


### PR DESCRIPTION
## Summary
- add `search` tool to find text strings or hex byte patterns and report their EAs
- register `search` in the tool metadata and dispatch table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5f612ab1c83238f6d52a81a3c4f6c