### PR TITLE
Add disassembly retrieval tool

### DIFF
--- a/gepetto/ida/cli.py
+++ b/gepetto/ida/cli.py
@@ -19,6 +19,8 @@ import gepetto.ida.tools.refresh_view
 import gepetto.ida.tools.rename_lvar
 import gepetto.ida.tools.rename_function
 import gepetto.ida.tools.to_hex
+import gepetto.ida.tools.get_disasm
+import gepetto.ida.tools.get_bytes
 
 _ = gepetto.config._
 CLI: ida_kernwin.cli_t = None
@@ -90,6 +92,10 @@ class GepettoCLI(ida_kernwin.cli_t):
                         gepetto.ida.tools.list_symbols.handle_list_symbols_tc(tc, MESSAGES)
                     elif tc.function.name == "to_hex":
                         gepetto.ida.tools.to_hex.handle_to_hex_tc(tc, MESSAGES)
+                    elif tc.function.name == "get_disasm":
+                        gepetto.ida.tools.get_disasm.handle_get_disasm_tc(tc, MESSAGES)
+                    elif tc.function.name == "get_bytes":
+                        gepetto.ida.tools.get_bytes.handle_get_bytes_tc(tc, MESSAGES)
                     elif tc.function.name == "get_callers":
                         gepetto.ida.tools.call_graph.handle_get_callers_tc(tc, MESSAGES)
                     elif tc.function.name == "get_callees":

--- a/gepetto/ida/tools/get_bytes.py
+++ b/gepetto/ida/tools/get_bytes.py
@@ -1,0 +1,70 @@
+import json
+from typing import Dict
+
+import ida_bytes
+import ida_kernwin
+
+from gepetto.ida.tools.function_utils import parse_ea
+from gepetto.ida.tools.tools import add_result_to_messages
+
+
+def handle_get_bytes_tc(tc, messages):
+    """Handle tool call for get_bytes."""
+    try:
+        args = json.loads(tc.function.arguments or "{}")
+    except Exception:
+        args = {}
+
+    ea = args.get("ea")
+    size = args.get("size", 0x20)
+    try:
+        ea = parse_ea(ea)
+        size = int(size)
+        result = get_bytes(ea, size)
+    except Exception as ex:
+        result = {
+            "ok": False,
+            "error": str(ex),
+            "ea": ea if isinstance(ea, int) else None,
+            "size": size if isinstance(size, int) else None,
+            "bytes": None,
+        }
+
+    add_result_to_messages(messages, tc, result)
+
+
+# -----------------------------------------------------------------------------
+
+
+def _read_bytes(ea: int, size: int) -> bytes:
+    out = {"data": b""}
+
+    def _do():
+        out["data"] = ida_bytes.get_bytes(ea, size) or b""
+        return 1
+
+    ida_kernwin.execute_sync(_do, ida_kernwin.MFF_READ)
+    return out["data"]
+
+
+def _format_bytes(bs: bytes) -> str:
+    return " ".join(f"0x{b:02X}" for b in bs)
+
+
+def get_bytes(ea: int, size: int = 0x20) -> Dict:
+    """Return raw bytes starting at a given EA."""
+    result = {
+        "ok": False,
+        "error": None,
+        "ea": ea,
+        "size": size,
+        "bytes": None,
+    }
+
+    try:
+        bs = _read_bytes(ea, size)
+        result.update(ok=True, bytes=_format_bytes(bs))
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result

--- a/gepetto/ida/tools/get_disasm.py
+++ b/gepetto/ida/tools/get_disasm.py
@@ -1,0 +1,77 @@
+import json
+from typing import Dict
+
+import ida_lines
+import ida_kernwin
+
+from gepetto.ida.tools.function_utils import parse_ea
+from gepetto.ida.tools.tools import add_result_to_messages
+
+
+def handle_get_disasm_tc(tc, messages):
+    """Handle tool call for get_disasm."""
+    try:
+        args = json.loads(tc.function.arguments or "{}")
+    except Exception:
+        args = {}
+
+    ea = args.get("ea")
+    try:
+        ea = parse_ea(ea)
+        result = get_disasm(ea)
+    except Exception as ex:
+        result = {
+            "ok": False,
+            "error": str(ex),
+            "ea": ea if isinstance(ea, int) else None,
+            "disasm": None,
+        }
+
+    add_result_to_messages(messages, tc, result)
+
+
+# -----------------------------------------------------------------------------
+
+
+def _get_disasm_line(ea: int) -> str:
+    out = {"text": ""}
+
+    def _do():
+        out["text"] = ida_lines.generate_disasm_line(ea, 0) or ""
+        return 1
+
+    ida_kernwin.execute_sync(_do, ida_kernwin.MFF_READ)
+    return out["text"]
+
+
+def get_disasm(ea: int) -> Dict:
+    """Return the disassembly line at a given EA.
+
+    Parameters:
+        ea (int): Effective address to disassemble.
+
+    Returns:
+        dict: {
+            "ok": bool,
+            "error": str | None,
+            "ea": int,
+            "disasm": str | None,
+        }
+    """
+    result = {
+        "ok": False,
+        "error": None,
+        "ea": ea,
+        "disasm": None,
+    }
+
+    try:
+        line = _get_disasm_line(ea)
+        result.update(
+            ok=True,
+            disasm=line,
+        )
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result

--- a/gepetto/ida/tools/tools.py
+++ b/gepetto/ida/tools/tools.py
@@ -51,6 +51,45 @@ TOOLS = [
     {
         "type": "function",
         "function": {
+            "name": "get_disasm",
+            "description": "Return disassembly for an effective address.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "ea": {
+                        "type": "integer",
+                        "description": "Effective address to disassemble.",
+                    },
+                },
+                "required": ["ea"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_bytes",
+            "description": "Return raw bytes for an effective address.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "ea": {
+                        "type": "integer",
+                        "description": "Effective address to read from.",
+                    },
+                    "size": {
+                        "type": "integer",
+                        "description": "Number of bytes to retrieve starting at the address.",
+                        "default": 32,
+                    },
+                },
+                "required": ["ea"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "get_function_code",
             "description": "Return Hex-Rays pseudocode for a function, resolved by EA or by name.",
             "parameters": {


### PR DESCRIPTION
## Summary
- add `get_disasm` tool to fetch disassembly text from a given EA
- add `get_bytes` tool to fetch raw bytes from a given EA
- expose both tools in CLI and tool registry

## Testing
- `python -m pytest tests/unit.py -q` *(fails: AttributeError 'NoneType' object has no attribute 'get')*


------
https://chatgpt.com/codex/tasks/task_e_68b6015dbc2083238dc242ffd2dc3d64