### PR TITLE
Fix plugin loading on IDA < 9 (interactive) & update OpenAI API keys link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Finally, with the corresponding interpreter, simply run:
 ```
 
 ⚠️ You will also need to edit the configuration file (found as `gepetto/config.ini`) and add your own API keys. For 
-OpenAI, it can be found on [this page](https://beta.openai.com/account/api-keys).
+OpenAI, it can be found on [this page](https://platform.openai.com/api-keys).
 Please note that API queries are usually not free (although not very expensive) and you will need to set up a payment 
 method with the corresponding provider.
 

--- a/gepetto/ida/ui.py
+++ b/gepetto/ida/ui.py
@@ -47,7 +47,7 @@ class GepettoPlugin(idaapi.plugin_t):
         if not ida_hexrays.init_hexrays_plugin():
             return idaapi.PLUGIN_SKIP
         # Only launch in interactive mode
-        if os.environ.get("IDA_IS_INTERACTIVE") != "1":
+        if not ida_kernwin.is_idaq():
             return idaapi.PLUGIN_SKIP
         # Check if Gepetto loaded at least one model properly
         if not gepetto.config.model:


### PR DESCRIPTION
Hi, and thanks for the project.

This PR includes two small changes:

1. Fix plugin loading on IDA versions < 9
   * Problem: the plugin was skipped on older IDA because it relied on `IDA_IS_INTERACTIVE`, which only exists in IDA >= 9 (see #88).
   * Change: make the interactive check compatible with older versions so the plugin still loads on supported IDA versions (>= 7.4) while skipping non-interactive runs.

2. Docs: update OpenAI API keys link
   * Replace the legacy URL with the current `https://platform.openai.com/account/api-keys`.

Hope this helps !