### PR TITLE
add metadata for plugin repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,28 @@ rename its variables. Here is a simple example of what results it can provide in
 
 ## Setup
 
-Simply drop this script (`gepetto.py`, as well as the `gepetto/` folder) into your IDA plugins folder (`$IDAUSR/plugins`). 
-By default, on Windows, this should be `%AppData%\Hex-Rays\IDA Pro\plugins` (you may need to create it).
-
-You will need to add the required packages to IDA's Python installation for the script to work.
-Find which interpreter IDA is using by checking the following registry key: 
-`Computer\HKEY_CURRENT_USER\Software\Hex-Rays\IDA` (default on Windows: `%LOCALAPPDATA%\Programs\Python\Python39`).
-Finally, with the corresponding interpreter, simply run: 
-
+### Using hcli (Recommended)
+The easiest way to install Gepetto is using the [Hex-Rays CLI tool (hcli)](https://github.com/HexRaysSA/ida-hcli):
+```bash
+pip install ida-hcli
+hcli plugin install gepetto
 ```
-[/path/to/python] -m pip install -r requirements.txt
-```
+
+This will automatically install the plugin to your IDA user directory.
+
+### Manual Installation
+Alternatively, you can manually install the plugin:
+1. Drop this script (`gepetto.py`, as well as the `gepetto/` folder) into your IDA plugins folder (`$IDAUSR/plugins`).
+2. The plugins directory location depends on your system:
+   - **Windows**: `%APPDATA%\Hex-Rays\IDA Pro\plugins\`
+   - **macOS**: `~/Library/Application Support/IDA Pro/plugins/`
+   - **Linux**: `~/.idapro/plugins/`
+3. Install the required packages to IDA's Python installation. Find which interpreter IDA is using by checking the following registry key:
+   `Computer\HKEY_CURRENT_USER\Software\Hex-Rays\IDA` (default on Windows: `%LOCALAPPDATA%\Programs\Python\Python39`).
+4. With the corresponding interpreter, simply run:
+   ```bash
+   [/path/to/python] -m pip install -r requirements.txt
+   ```
 
 ⚠️ You will also need to edit the configuration file (found as `gepetto/config.ini`) and add your own API keys. For 
 OpenAI, it can be found on [this page](https://platform.openai.com/api-keys).

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -1,12 +1,50 @@
 {
   "IDAMetadataDescriptorVersion": 1,
   "plugin": {
-    "name": "Gepetto",
+    "name": "gepetto",
     "entryPoint": "gepetto.py",
-    "categories": ["integration-with-third-parties/interoperability"],
-    "logoPath": "readme/gepetto_logo.png",
+    "version": "1.4.1",
     "idaVersions": ">=7.4",
     "description": "Gepetto is a Python plugin which uses various large language models to provide meaning to functions decompiled by IDA Pro. It can leverage them to explain what a function does, and to automatically rename its variables.",
-    "version": "1.4.1"
+    "license": "GPL-3.0",
+    "categories": [
+      "integration-with-third-parties-interoperability",
+      "decompilation",
+      "api-scripting-and-automation",
+      "collaboration-and-productivity"
+    ],
+    "pythonDependencies": [
+      "openai>=1.101.0",
+      "groq>=0.8.0",
+      "together>=1.2.0",
+      "ollama>=0.4.5",
+      "azure-identity>=1.21.0",
+      "google-generativeai"
+    ],
+    "urls": {
+      "repository": "https://github.com/JusticeRage/Gepetto"
+    },
+    "authors": [{
+      "name": "Ivan Kwiatkowski",
+      "email": "justicerage@manalyzer.org"
+    }],
+    "keywords": [
+      "llm",
+      "ai",
+      "gpt",
+      "openai",
+      "gemini",
+      "ollama",
+      "code-explanation",
+      "variable-renaming",
+      "auto-comment",
+      "decompilation-analysis",
+      "reverse-engineering-assistant",
+      "natural-language",
+      "azure-openai",
+      "groq",
+      "together",
+      "deepseek"
+    ]
   }
 }


### PR DESCRIPTION
Thanks for your work on this plugin!

Hex-Rays is developing a plugin manager for IDA Pro plugins. You've probably seen plugins.hex-rays.com but noticed it doesn't really help users get the code configured on their system. This plugin manager is meant to fix that - think of it like `apt` or `pip` for IDA Pro plugins.

The initial version is available via the [Hex-Rays CLI tool (hcli)](https://github.com/HexRaysSA/ida-hcli). You can install it off PyPI like this: `pip install ida-hcli` (note the plugin manager is sitting on a different branch today, sorry!).

From there, users can do things like:

```console
$ hcli plugin search deepseek
$ hcli plugin install gepetto
$ hcli plugin upgrade gepetto
$ hcli plugin uninstall gepetto
```

For more information about the plugin manager, you can review the documentation here:
https://github.com/HexRaysSA/ida-hcli/blob/plugin-manager/docs/reference/plugins.md

Anyways, to work with the plugin manager, some (hopefully reasonable) changes are needed to Gepetto. I'm happy to propose changes and help with testing. Don't hesitate to tag me here or email me at wballenthin@hex-rays.com.

Here's what I'd propose: a bit more metadata in `ida-plugin.json`. Please see the PR diff.

Note: we're in a sort of pre-release time period, where the plugin manager is roughly done
 but the plugin repository isn't fully populated. So I'm doing the pre-work to get a bunch of useful plugins upgraded and indexed. Then we can have a big release and get people excited about easily installing Gepetto :-)
