### PR TITLE
feat(ui): add dockable status panel with streaming output

### DIFF
--- a/gepetto/ida/cli.py
+++ b/gepetto/ida/cli.py
@@ -7,6 +7,7 @@ import ida_idaapi
 
 import gepetto.config
 import gepetto.ida.handlers
+from gepetto.ida.status_panel import get_status_panel
 from gepetto.ida.tools.tools import TOOLS
 import gepetto.ida.tools.call_graph
 import gepetto.ida.tools.get_ea
@@ -44,6 +45,8 @@ MESSAGES: list[dict] = [
     }
 ]  # Keep a history of the conversation to simulate LLM memory.
 
+STATUS_PANEL = get_status_panel()
+
 
 class GepettoCLI(ida_kernwin.cli_t):
     flags = 0
@@ -56,6 +59,13 @@ class GepettoCLI(ida_kernwin.cli_t):
             return True
 
         MESSAGES.append({"role": "user", "content": line})
+        STATUS_PANEL.ensure_shown()
+        STATUS_PANEL.set_stop_callback(getattr(gepetto.config.model, "cancel_current_request", None))
+        STATUS_PANEL.reset_stop()
+        STATUS_PANEL.set_model(str(gepetto.config.model))
+        STATUS_PANEL.set_status(_("Waiting for model..."), busy=True)
+        STATUS_PANEL.log_user(line)
+        STATUS_PANEL.start_stream(str(gepetto.config.model))
 
         def handle_response(response):
             if hasattr(response, "tool_calls") and response.tool_calls:
@@ -77,6 +87,8 @@ class GepettoCLI(ida_kernwin.cli_t):
                         "tool_calls": tool_calls,
                     }
                 )
+                STATUS_PANEL.log(_("→ Model requested tool: {tool_name} ({tool_args}...)").format(tool_name=tc.function.name, tool_args=(tc.function.arguments or '')[:120]))
+                STATUS_PANEL.set_status(_("Using tool: {tool_name}").format(tool_name=tc.function.name), busy=True)
                 for tc in response.tool_calls:
                     if tc.function.name == "get_screen_ea":
                         gepetto.ida.tools.get_screen_ea.handle_get_screen_ea_tc(tc, MESSAGES)
@@ -110,7 +122,11 @@ class GepettoCLI(ida_kernwin.cli_t):
                         gepetto.ida.tools.refresh_view.handle_refresh_view_tc(tc, MESSAGES)
                 stream_and_handle()
             else:
-                MESSAGES.append({"role": "assistant", "content": response.content or ""})
+                content = response.content or ""
+                MESSAGES.append({"role": "assistant", "content": content})
+                STATUS_PANEL.set_status(_("Done"), busy=False)
+                STATUS_PANEL.finish_stream(content)
+                STATUS_PANEL.log(_("✔ Completed turn"))
 
         def stream_and_handle():
             message = SimpleNamespace(content="", tool_calls=[])
@@ -119,10 +135,12 @@ class GepettoCLI(ida_kernwin.cli_t):
                 if isinstance(delta, str):
                     print(delta, end="", flush=True)
                     message.content += delta
+                    STATUS_PANEL.append_stream(delta)
                     return
                 if getattr(delta, "content", None):
                     print(delta.content, end="", flush=True)
                     message.content += delta.content
+                    STATUS_PANEL.append_stream(delta.content)
                 if getattr(delta, "tool_calls", None):
                     for tc in delta.tool_calls:
                         idx = tc.index

--- a/gepetto/ida/comment_handler.py
+++ b/gepetto/ida/comment_handler.py
@@ -12,8 +12,11 @@ import idc
 
 import gepetto.config
 from gepetto.models.model_manager import instantiate_model
+from gepetto.ida.status_panel import get_status_panel
 
 _ = gepetto.config._
+
+STATUS_PANEL = get_status_panel()
 
 # -----------------------------------------------------------------------------
 
@@ -50,7 +53,9 @@ class CommentHandler(idaapi.action_handler_t):
               """,
             functools.partial(comment_callback, decompiler_output=decompiler_output, pseudocode_lines=pseudocode_lines, view=v, start_time=start_time),
             additional_model_options={"response_format": {"type": "json_object"}})
-        print(_("Request to {model} sent...").format(model=str(gepetto.config.model)))
+        request_sent = _("Request to {model} sent...").format(model=str(gepetto.config.model))
+        print(request_sent)
+        STATUS_PANEL.log(request_sent)
         return 1
 
     # This action is always available.
@@ -90,9 +95,11 @@ def comment_callback(decompiler_output, pseudocode_lines, view, response, start_
         if view:
             view.refresh_view(True)
 
-        print(_("{model} query finished in {time:.2f} seconds!").format(
-            model=str(gepetto.config.model), time=elapsed_time))
-        
+        response_finished = _("{model} query finished in {time:.2f} seconds!").format(
+            model=str(gepetto.config.model), time=elapsed_time)
+        print(response_finished)
+        STATUS_PANEL.log(response_finished)
+
     except Exception as e:
         print("[ERROR] comment_callback:", e)
         raise

--- a/gepetto/ida/handlers.py
+++ b/gepetto/ida/handlers.py
@@ -10,9 +10,11 @@ import idc
 
 import gepetto.config
 from gepetto.models.model_manager import instantiate_model
+from gepetto.ida.status_panel import get_status_panel
 
 _ = gepetto.config._
 
+STATUS_PANEL = get_status_panel()
 
 def comment_callback(address, view, response, start_time):
     """Callback that sets a comment at the given address.
@@ -46,7 +48,10 @@ def comment_callback(address, view, response, start_time):
     # Refresh the window so the comment is displayed properly
     if view:
         view.refresh_view(False)
-    print(_("{model} query finished in {time:.2f} seconds!").format(model=str(gepetto.config.model), time=elapsed_time))
+        response_finished = _("{model} query finished in {time:.2f} seconds!").format(
+            model=str(gepetto.config.model), time=elapsed_time)
+        print(response_finished)
+        STATUS_PANEL.log(response_finished)
 
 # -----------------------------------------------------------------------------
 
@@ -89,7 +94,9 @@ class ExplainHandler(idaapi.action_handler_t):
             f"Your response should use the following locale as a language: {gepetto.config.get_localization_locale()}\n"
             f"{decompiler_output}",
             functools.partial(comment_callback, address=idaapi.get_screen_ea(), view=v, start_time=start_time))
-        print(_("Request to {model} sent...").format(model=str(gepetto.config.model)))
+        request_sent = _("Request to {model} sent...").format(model=str(gepetto.config.model))
+        print(request_sent)
+        STATUS_PANEL.log(request_sent)
         return 1
 
     # This action is always available.
@@ -175,7 +182,9 @@ def rename_callback(address, view, response):
 
     if view:
         view.refresh_view(True)
-    print(_("Done! {count} name(s) renamed.").format(count=len(replaced)))
+    response_finished = _("Done! {count} name(s) renamed.").format(count=len(replaced))
+    print(response_finished)
+    STATUS_PANEL.log(response_finished)
 
 
 # -----------------------------------------------------------------------------
@@ -202,7 +211,9 @@ class RenameHandler(idaapi.action_handler_t):
             f"Your response should suggest names in the following locale: {gepetto.config.get_localization_locale()}",
             functools.partial(rename_callback, address=idaapi.get_screen_ea(), view=v),
             additional_model_options={"response_format": {"type": "json_object"}})
-        print(_("Request to {model} sent...").format(model=str(gepetto.config.model)))
+        request_sent = _("Request to {model} sent...").format(model=str(gepetto.config.model))
+        print(request_sent)
+        STATUS_PANEL.log(request_sent)
         return 1
 
     # This action is always available.
@@ -226,7 +237,9 @@ class SwapModelHandler(idaapi.action_handler_t):
         try:
             gepetto.config.model = instantiate_model(self.new_model)
         except ValueError as e:  # Raised if an API key is missing. In which case, don't switch.
-            print(_("Couldn't change model to {model}: {error}").format(model=self.new_model, error=str(e)))
+            error_msg = _("Couldn't change model to {model}: {error}").format(model=self.new_model, error=str(e))
+            print(error_msg)
+            STATUS_PANEL.log(error_msg)
             return
         gepetto.config.update_config("Gepetto", "MODEL", self.new_model)
         # Refresh the menus to reflect which model is currently selected.
@@ -254,7 +267,9 @@ class GenerateCCodeHandler(idaapi.action_handler_t):
             _("Please generate executable C code based on the following decompiled C code and ensure it includes all necessary header files and other information:\n{decompiler_output}").format(decompiler_output=str(decompiler_output)),
             functools.partial(self._save_c_code, view=v)
         )
-        print(_("Request to {model} sent...").format(model=str(gepetto.config.model)))
+        request_sent = _("Request to {model} sent...").format(model=str(gepetto.config.model))
+        print(request_sent)
+        STATUS_PANEL.log(request_sent)
         return 1
 
     def _save_c_code(self, view, response):
@@ -271,7 +286,10 @@ class GenerateCCodeHandler(idaapi.action_handler_t):
 
         if view:
             view.refresh_view(False)
-        print(_("{model} generated code saved to {file_name}").format(model=str(gepetto.config.model), file_name=file_name))
+        response_finished = _("{model} generated code saved to {file_name}").format(
+            model=str(gepetto.config.model), file_name=file_name)
+        print(response_finished)
+        STATUS_PANEL.log(response_finished)
 
     def update(self, ctx):
         return idaapi.AST_ENABLE_ALWAYS
@@ -295,7 +313,9 @@ class GeneratePythonCodeHandler(idaapi.action_handler_t):
             _("Please generate equivalent Python code based on the following decompiled C code, and provide an example of the function call:\n{decompiler_output}").format(decompiler_output=str(decompiler_output)),
             functools.partial(self._save_python_code, view=v)
         )
-        print(_("Request to {model} sent...").format(model=str(gepetto.config.model)))
+        request_sent = _("Request to {model} sent...").format(model=str(gepetto.config.model))
+        print(request_sent)
+        STATUS_PANEL.log(request_sent)
         return 1
 
     def _save_python_code(self, view, response):
@@ -312,7 +332,11 @@ class GeneratePythonCodeHandler(idaapi.action_handler_t):
 
         if view:
             view.refresh_view(False)
-        print(_("{model} generated code saved to {file_name}").format(model=str(gepetto.config.model), file_name=file_name))
+        response_finished = _("{model} generated code saved to {file_name}").format(
+            model=str(gepetto.config.model), file_name=file_name)
+        print(response_finished)
+        STATUS_PANEL.log(response_finished)
+        
 
     def update(self, ctx):
         return idaapi.AST_ENABLE_ALWAYS

--- a/gepetto/ida/status_panel.py
+++ b/gepetto/ida/status_panel.py
@@ -1,0 +1,392 @@
+"""Qt5 status panel mirroring the original Gepetto UI layout."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Callable, Optional
+
+import ida_kernwin
+
+import gepetto.config
+
+_ = gepetto.config._
+
+try:  # Prefer PyQt5 on IDA 7.x; fall back to PySide6 for newer builds.
+    from PyQt5 import QtCore, QtGui, QtWidgets  # type: ignore
+except ImportError:  # pragma: no cover - executed on IDA >= 9.2 with PySide6
+    try:
+        from PySide6 import QtCore, QtGui, QtWidgets  # type: ignore
+    except ImportError:  # pragma: no cover - headless testing environment
+        QtCore = QtGui = QtWidgets = None  # type: ignore
+
+
+def _timestamp() -> str:
+    return datetime.datetime.now().strftime("%H:%M:%S")
+
+
+class GepettoStatusForm(ida_kernwin.PluginForm):
+    """Dockable widget that displays the streaming answer and log."""
+
+    def __init__(self, owner: "_StatusPanelManager") -> None:
+        super().__init__()
+        self._owner = owner
+        self._widget: Optional[QtWidgets.QWidget] = None if QtWidgets else None
+        self._log: Optional[QtWidgets.QTextEdit] = None
+        self._model_label: Optional[QtWidgets.QLabel] = None
+        self._status_label: Optional[QtWidgets.QLabel] = None
+        self._stop_button: Optional[QtWidgets.QPushButton] = None
+        self._clear_button: Optional[QtWidgets.QPushButton] = None
+        self._stream_active = False
+        self._stream_text: list[str] = []
+        self._ready = False
+
+    # ------------------------------------------------------------------
+    def OnCreate(self, form):  # noqa: N802 - IDA callback signature
+        if QtWidgets is None:
+            return
+        self._widget = ida_kernwin.PluginForm.FormToPyQtWidget(form)
+        self._build_ui()
+        self._ready = True
+        self._owner.on_form_ready()
+
+    # ------------------------------------------------------------------
+    def OnClose(self, form):  # noqa: N802 - IDA callback signature
+        del form
+        self._widget = None
+        self._log = None
+        self._model_label = None
+        self._status_label = None
+        self._stop_button = None
+        self._clear_button = None
+        self._stream_active = False
+        self._stream_text = []
+        self._ready = False
+        self._owner.form_closed()
+
+    # ------------------------------------------------------------------
+    def is_ready(self) -> bool:
+        return bool(self._widget and self._ready)
+
+    # ------------------------------------------------------------------
+    def widget(self):  # noqa: ANN001 - helper used by the manager
+        return self._widget
+
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        if QtWidgets is None or self._widget is None:
+            return
+
+        layout = QtWidgets.QVBoxLayout(self._widget)
+        layout.setContentsMargins(6, 6, 6, 6)
+        layout.setSpacing(6)
+
+        top_row = QtWidgets.QHBoxLayout()
+        top_row.addStretch(1)
+        self._clear_button = QtWidgets.QPushButton(_("Clear"))
+        self._clear_button.clicked.connect(self._owner.clear_log)  # type: ignore[arg-type]
+        top_row.addWidget(self._clear_button)
+        layout.addLayout(top_row)
+
+        self._log = QtWidgets.QTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setMinimumHeight(160)
+        try:
+            self._log.document().setMaximumBlockCount(2000)
+        except Exception:
+            pass
+        layout.addWidget(self._log, stretch=1)
+
+        bottom_row = QtWidgets.QHBoxLayout()
+        self._model_label = QtWidgets.QLabel(_("Model: {model}").format(model=str(gepetto.config.model)))
+        bottom_row.addWidget(self._model_label)
+        bottom_row.addStretch(1)
+        self._status_label = QtWidgets.QLabel(_("Status: {status}").format(status=_("Idle")))
+        bottom_row.addWidget(self._status_label)
+
+        self._stop_button = QtWidgets.QPushButton(_("Stop"))
+        self._stop_button.setVisible(True)
+        self._stop_button.setEnabled(False)
+        self._stop_button.clicked.connect(self._owner.request_stop)  # type: ignore[arg-type]
+        bottom_row.addWidget(self._stop_button)
+
+        layout.addLayout(bottom_row)
+
+    # ------------------------------------------------------------------
+
+    def _force_cursor_to_end(self):
+        if QtGui is None:
+            return
+        self._log.moveCursor(QtGui.QTextCursor.End)
+
+    def _ensure_line_start(self):
+        if QtGui is None:
+            return
+        try:
+            doc_text = self._log.toPlainText()
+            if doc_text and not doc_text.endswith("\n"):
+                self._log.moveCursor(QtGui.QTextCursor.End)
+                self._log.insertPlainText("\n")
+        except Exception:
+            pass
+
+    def _ensure_trailing_newline(self):
+        if QtGui is None:
+            return
+        try:
+            doc_text = self._log.toPlainText()
+            if not doc_text.endswith("\n"):
+                self._log.moveCursor(QtGui.QTextCursor.End)
+                self._log.insertPlainText("\n")
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def set_model(self, model_name: str) -> None:
+        if self._model_label:
+            self._model_label.setText(_("Model: {model}").format(model=model_name))
+
+    # ------------------------------------------------------------------
+    def set_status(self, text: str, *, busy: bool = False, error: bool = False) -> None:
+        if self._status_label is None:
+            return
+        status_text = text or _("Idle")
+        self._status_label.setText(_("Status: {status}").format(status=status_text))
+        if QtGui is None:
+            return
+        palette = self._status_label.palette()
+        if error:
+            palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("#c92a2a"))
+        elif busy:
+            palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("#e67700"))
+        else:
+            palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("#2f9e44"))
+        self._status_label.setPalette(palette)
+
+    # ------------------------------------------------------------------
+    def reset_stop(self) -> None:
+        if self._stop_button is None:
+            return
+        self._stop_button.setText(_("Stop"))
+        self._stop_button.setEnabled(self._owner.has_stop_callback())
+
+    # ------------------------------------------------------------------
+    def set_stop_callback(self, callback: Optional[Callable[[], None]]) -> None:
+        if self._stop_button is None:
+            return
+        self._stop_button.setEnabled(callback is not None)
+
+    # ------------------------------------------------------------------
+    def mark_error(self, message: str) -> None:
+        self.set_status(message, error=True)
+        if self._stop_button:
+            self._stop_button.setEnabled(False)
+
+    # ------------------------------------------------------------------
+    def clear_log(self) -> None:
+        if self._log:
+            self._log.clear()
+
+    # ------------------------------------------------------------------
+    def append_log(self, message: str) -> None:
+        if not self._log:
+            return
+        entry = f"{_timestamp()} : {message}"
+        self._ensure_line_start()
+        self._force_cursor_to_end()
+        self._log.insertPlainText(entry)
+        if QtWidgets:
+            self._log.verticalScrollBar().setValue(self._log.verticalScrollBar().maximum())
+
+    # ------------------------------------------------------------------
+    def log_user(self, text: str) -> None:
+        self.append_log(f"[{_('You')}] {text}")
+
+    # ------------------------------------------------------------------
+    def log_assistant(self, text: str) -> None:
+        self.append_log(f"[{_('Gepetto')}] {text}")
+
+    # ------------------------------------------------------------------
+    def start_stream(self, model_name: Optional[str]) -> None:
+        if model_name:
+            self.set_model(model_name)
+        if not self._log or QtGui is None:
+            return
+        header = f"[{_('Gepetto')} ({model_name})] " if model_name is not None else f"[{_('Gepetto')}]"
+        self._stream_text = []
+        self._stream_active = True
+        self.append_log(header)
+
+    # ------------------------------------------------------------------
+    def append_stream(self, chunk: str) -> None:
+        if not self._stream_active or not chunk or not self._log or QtGui is None:
+            return
+        self._stream_text.append(chunk)
+        self._force_cursor_to_end()
+        self._log.insertPlainText(chunk)
+
+    # ------------------------------------------------------------------
+    def finish_stream(self, final_text: str) -> None:
+        finished_message = "".join(self._stream_text)
+        self._stream_text = []
+        self._stream_active = False
+        if not self._log or QtGui is None:
+            return
+        if final_text != finished_message:
+            self.log_assistant(final_text)
+        self._ensure_trailing_newline()
+
+
+class _StatusPanelManager:
+    """Controller keeping a singleton instance of the status panel."""
+
+    def __init__(self) -> None:
+        self._form: Optional[GepettoStatusForm] = None
+        self._stop_callback: Optional[Callable[[], None]] = None
+        self._docked = False
+
+    # ------------------------------------------------------------------
+    def ensure_shown(self) -> None:
+        if self._form is None:
+            self._form = GepettoStatusForm(self)
+            options = getattr(ida_kernwin.PluginForm, "WOPN_PERSIST", 0)
+            options |= getattr(ida_kernwin.PluginForm, "WOPN_RESTORE", 0)
+            try:
+                self._form.Show(_("Gepetto Status"), options=options)
+            except Exception:
+                print(_("Could not show Gepetto Status panel."))
+                return
+        try:
+            ida_kernwin.activate_widget(_("Gepetto Status"), True)
+            self._dock()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def form_closed(self) -> None:
+        self._form = None
+        self._docked = False
+
+    # ------------------------------------------------------------------
+    def on_form_ready(self) -> None:
+        self._dock()
+        if self._stop_callback:
+            self._form.set_stop_callback(self._stop_callback)  # type: ignore[union-attr]
+            self._form.reset_stop()
+
+    # ------------------------------------------------------------------
+    def _dock(self) -> None:
+        if self._form is None or not self._form.is_ready() or self._docked:
+            return
+        if self._form._widget and ida_kernwin.find_widget("IDA View-A"):
+            if ida_kernwin.set_dock_pos(_("Gepetto Status"), "IDA View-A", ida_kernwin.DP_RIGHT):
+                self._docked = True
+
+    # ------------------------------------------------------------------
+    def set_model(self, model_name: str) -> None:
+        self._dispatch(lambda form: form.set_model(model_name))
+
+    # ------------------------------------------------------------------
+    def set_status(self, text: str, *, busy: bool = False, error: bool = False) -> None:
+        self._dispatch(lambda form: form.set_status(text, busy=busy, error=error))
+
+    # ------------------------------------------------------------------
+    def reset_stop(self) -> None:
+        self._dispatch(lambda form: form.reset_stop())
+
+    # ------------------------------------------------------------------
+    def set_stop_callback(self, callback: Optional[Callable[[], None]]) -> None:
+        self._stop_callback = callback
+        def apply(form: GepettoStatusForm) -> None:
+            form.set_stop_callback(callback)
+            form.reset_stop()
+
+        self._dispatch(apply)
+
+    # ------------------------------------------------------------------
+    def has_stop_callback(self) -> bool:
+        return self._stop_callback is not None
+
+    # ------------------------------------------------------------------
+    def request_stop(self) -> None:
+        if self._stop_callback:
+            try:
+                self._stop_callback()
+            except Exception:
+                pass
+            finally:
+                self.set_status(_("Idle"))
+                self.reset_stop()
+
+    # ------------------------------------------------------------------
+    def start_stream(self, model_name: Optional[str]) -> None:
+        self._dispatch(lambda form: form.start_stream(model_name))
+
+    # ------------------------------------------------------------------
+    def append_stream(self, chunk: str) -> None:
+        self._dispatch(lambda form: form.append_stream(chunk))
+
+    # ------------------------------------------------------------------
+    def finish_stream(self, final_text: str) -> None:
+        self._dispatch(lambda form: form.finish_stream(final_text))
+
+    # ------------------------------------------------------------------
+    def log_user(self, text: str) -> None:
+        self._dispatch(lambda form: form.log_user(text))
+
+    # ------------------------------------------------------------------
+    def log(self, message: str) -> None:
+        self._dispatch(lambda form: form.append_log(message))
+
+    # ------------------------------------------------------------------
+    def mark_error(self, message: str) -> None:
+        self._dispatch(lambda form: form.mark_error(message))
+
+    # ------------------------------------------------------------------
+    def clear_log(self) -> None:
+        self._dispatch(lambda form: form.clear_log())
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        if self._form and self._form.is_ready():
+            try:
+                ida_kernwin.close_widget(self._form.widget(), 0)
+            except Exception:
+                pass
+        self._form = None
+        self._stop_callback = None
+        self._docked = False
+
+    # ------------------------------------------------------------------
+
+    def _dispatch(self, action: Callable[[GepettoStatusForm], None]) -> None:
+        if self._form is None:
+            return
+
+        def runner() -> None:
+            form = self._form
+            if not form or not form.is_ready():
+                return
+            try:
+                action(form)
+            except Exception:
+                pass
+
+        widget = self._form.widget() if self._form else None
+        if QtCore and widget:
+            current_thread = QtCore.QThread.currentThread()
+            widget_thread = widget.thread()
+            if widget_thread == current_thread:
+                runner()
+                return
+
+        try:
+            ida_kernwin.execute_sync(runner, ida_kernwin.MFF_FAST)
+        except Exception:
+            runner()
+
+
+panel = _StatusPanelManager()
+
+
+def get_status_panel() -> _StatusPanelManager:
+    return panel

--- a/gepetto/ida/ui.py
+++ b/gepetto/ida/ui.py
@@ -12,6 +12,7 @@ import gepetto.config
 from gepetto.ida.handlers import ExplainHandler, RenameHandler, SwapModelHandler, GenerateCCodeHandler, GeneratePythonCodeHandler
 from gepetto.ida.comment_handler import CommentHandler
 from gepetto.ida.cli import register_cli
+from gepetto.ida.status_panel import get_status_panel
 import gepetto.models.model_manager
 
 _ = gepetto.config._
@@ -123,6 +124,7 @@ class GepettoPlugin(idaapi.plugin_t):
 
         # Register CLI
         register_cli()
+        ida_kernwin.execute_sync(lambda: get_status_panel().ensure_shown(), ida_kernwin.MFF_FAST)
 
         return idaapi.PLUGIN_KEEP
 
@@ -192,6 +194,7 @@ class GepettoPlugin(idaapi.plugin_t):
         self.detach_actions()
         if self.menu:
             self.menu.unhook()
+        get_status_panel().close()
         return
 
 
@@ -206,4 +209,3 @@ class ContextMenuHooks(idaapi.UI_Hooks):
             idaapi.attach_action_to_popup(form, popup, GepettoPlugin.rename_action_name, "Gepetto/")
             idaapi.attach_action_to_popup(form, popup, GepettoPlugin.c_code_action_name, "Gepetto/")
             idaapi.attach_action_to_popup(form, popup, GepettoPlugin.python_code_action_name, "Gepetto/")
-


### PR DESCRIPTION
- Introduce a new status_panel module with a dockable GepettoStatusForm and manager to display streaming LLM responses, log entries, and stop/clear controls in a sidebar.
- Integrate the status panel into the Gepetto CLI to show the panel on user input and model streaming, updating status, logs, and controls.
- Enforced thread safety on all operations
- Ensure the panel is automatically shown on plugin startup and closed when the plugin is unloaded.

Tested all context menu options on gemini-2.5-flash, plus chat for gpt-5-nano and gpt-4o (Gemini API fixes in another PR),

Refactored from planned overhaul in #106 

<img width="1300" height="926" alt="image" src="https://github.com/user-attachments/assets/fb4e3963-c83f-4bf3-88da-1765a5a48f92" />


