### PR TITLE
use settings infrastructure (example)

### DIFF
--- a/gepetto/config.py
+++ b/gepetto/config.py
@@ -2,6 +2,8 @@ import configparser
 import gettext
 import os
 
+import ida_settings
+
 from gepetto.models.model_manager import instantiate_model, load_available_models, get_fallback_model
 
 # =============================================================================
@@ -73,7 +75,7 @@ def load_config():
     _translator = translate.gettext
 
     # Select model
-    requested_model = parsed_ini.get('Gepetto', 'MODEL')
+    requested_model = ida_settings.get_current_plugin_setting("model")
     load_available_models()
     # Attempt to load the requested model, otherwise get the first available one, or don't load Gepetto
     try:

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -19,7 +19,8 @@
       "together>=1.2.0",
       "ollama>=0.4.5",
       "azure-identity>=1.21.0",
-      "google-generativeai"
+      "google-generativeai",
+      "ida-settings>=3.0.0"
     ],
     "urls": {
       "repository": "https://github.com/JusticeRage/Gepetto"
@@ -45,6 +46,16 @@
       "groq",
       "together",
       "deepseek"
+    ],
+    "settings": [
+      {
+        "key": "model",
+        "type": "string",
+        "required": true,
+        "default": "gpt-4o",
+        "name": "model",
+        "documentation": "model to use"
+      }
     ]
   }
 }


### PR DESCRIPTION
This PR introduces an example for how to use the IDA Pro plugin settings manager.

[hcli](https://hcli.docs.hex-rays.com) is the official command line tool for managing Hex-Rays software, like IDA Pro. It has a [plugin manager](https://github.com/HexRaysSA/ida-hcli/blob/main/docs/reference/plugin-manager.md) that uses the [plugin repository](https://plugins.hex-rays.com) to install IDA Pro plugins. The plugin manager relies on `ida-plugin.json` to declare metadata, like name/version/python dependencies. 

Based on our [shared design](https://docs.google.com/document/d/1DKSEN9_8qrIF0HBYEaJwD7LYXPCJ4B7EjhiibtyLtv4/edit?usp=sharing), I've introduced settings handling, too. hcli uses the settings declared in `ida-plugin.json` to prompt the user for required or optional settings, and persists them into a central place (`ida-config.json`). During plugin runtime, IDA Pro plugins can fetch their configuration, using [ida-settings](https://pypi.org/project/ida-settings/) (v3+).

This PR demonstrates how to use the new settings manager. However, I found that Gepetto has a large number of possible settings, so rather than port everything, I thought I'd show you a taste and decide if its time to refactor :-)

Here's an example showing hcli prompting for settings and then installing gepetto:

<img width="873" height="81" alt="image" src="https://github.com/user-attachments/assets/1b0181f1-4668-49b9-b6ec-e31220414f02" />
 