### PR TITLE
fix(ui): Qt5/Qt6 groundwork; wire request timers

### DIFF
--- a/gepetto/config.ini
+++ b/gepetto/config.ini
@@ -21,12 +21,21 @@ API_KEY =
 # Leave blank unless you know what you are doing :)
 BASE_URL =
 
-[AzureOpenAI]
-# Set your Azure OpenAI resource URL here, or put it in the AZURE_OPENAI_URL environment variable.
+[Gemini]
+# Set your Google Gemini API key here, or put it in the GEMINI_API_KEY environment variable.
+API_KEY = 
+
+# Base URL for the Gemini API. Defaults to Google's official endpoint.
+# Leave blank unless you have a specific reason to change it.
 BASE_URL =
+
+[AzureOpenAI]
 # Set your API key here, or put it in the AZURE_OPENAI_API_KEY environment variable.
 # If API_KEY is not set, the plugin will use Entra ID auth
 API_KEY =
+
+# Set your Azure OpenAI resource URL here, or put it in the AZURE_OPENAI_URL environment variable.
+BASE_URL =
 
 [LMStudio]
 BASE_URL =
@@ -122,11 +131,3 @@ BASE_URL =
 # Optional: Override the default models that will be available in the model selection menu.
 # Leave empty to use all available models.
 MODELS =
-
-[Gemini]
-# Set your Google Gemini API key here, or put it in the GEMINI_API_KEY environment variable.
-API_KEY = 
-
-# Base URL for the Gemini API. Defaults to Google's official endpoint.
-# Leave blank unless you have a specific reason to change it.
-BASE_URL =

--- a/gepetto/models/gemini.py
+++ b/gepetto/models/gemini.py
@@ -14,10 +14,11 @@ import gepetto.config
 _ = gepetto.config._
 
 
+GEMINI_FLASH_LATEST_MODEL_NAME = "gemini-flash-latest"
+GEMINI_FLASH_LITE_LATEST_MODEL_NAME = "gemini-flash-lite-latest"
 GEMINI_2_0_FLASH_MODEL_NAME = "gemini-2.0-flash"
 GEMINI_2_5_PRO_MODEL_NAME = "gemini-2.5-pro"
 GEMINI_2_5_FLASH_MODEL_NAME = "gemini-2.5-flash"
-GEMINI_2_5_FLASH_LITE_PREVIEW_MODEL_NAME = "gemini-2.5-flash-lite-preview-06-17"
 
 
 def _get(obj, key, default=None):
@@ -221,10 +222,11 @@ class Gemini(LanguageModel):
     @staticmethod
     def supported_models():
         return [
+            GEMINI_FLASH_LATEST_MODEL_NAME,
+            GEMINI_FLASH_LITE_LATEST_MODEL_NAME,
             GEMINI_2_0_FLASH_MODEL_NAME,
             GEMINI_2_5_PRO_MODEL_NAME,
             GEMINI_2_5_FLASH_MODEL_NAME,
-            GEMINI_2_5_FLASH_LITE_PREVIEW_MODEL_NAME,
         ]
 
     @staticmethod


### PR DESCRIPTION
- Status panel: gate QTextCursor move op for PyQt5/PySide6, guard scrollbar access, remove max block count, and drop palette-based status coloring to avoid Qt API differences.
- Rename flow: pass start_time and call STATUS_PANEL.log_request_finished to record elapsed time; print timer/status messages.
- GenerateCCode: add missing newline in prompt.
- Fix new Gemini model names that were supposed to be in earlier PR
- config.ini: relocate [Gemini] section near the top for visibility