### PR TITLE
refactor(models): rework Gemini streaming & tools

### DIFF
--- a/gepetto/models/gemini.py
+++ b/gepetto/models/gemini.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import functools
 import json
 import threading
+from collections.abc import Iterable
 from types import SimpleNamespace
+from typing import Any
 
 import ida_kernwin
 from google import genai
@@ -13,205 +17,285 @@ import gepetto.config
 
 _ = gepetto.config._
 
-
-GEMINI_FLASH_LATEST_MODEL_NAME = "gemini-flash-latest"
-GEMINI_FLASH_LITE_LATEST_MODEL_NAME = "gemini-flash-lite-latest"
 GEMINI_2_0_FLASH_MODEL_NAME = "gemini-2.0-flash"
 GEMINI_2_5_PRO_MODEL_NAME = "gemini-2.5-pro"
 GEMINI_2_5_FLASH_MODEL_NAME = "gemini-2.5-flash"
+GEMINI_FLASH_LATEST_MODEL_NAME = "gemini-flash-latest"
+GEMINI_FLASH_LITE_LATEST_MODEL_NAME = "gemini-flash-lite-latest"
 
+_DEFAULT_SAFETY_SETTINGS: tuple[types.SafetySetting, ...] = (
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+)
 
-def _get(obj, key, default=None):
-    if isinstance(obj, dict):
-        return obj.get(key, default)
-    return getattr(obj, key, default)
-
-
-def _convert_messages(messages):
-    system_instruction = None
-    gemini_messages = []
-    for m in messages:
-        role = _get(m, "role")
-        content = _get(m, "content", "")
-        if role == "system":
-            system_instruction = (
-                f"{system_instruction}\n{content}" if system_instruction else content
-            )
-            continue
-        if role == "user":
-            gemini_messages.append({"role": "user", "parts": [{"text": content}]})
-        elif role == "assistant":
-            # Prefer raw Gemini parts if present to preserve thought signatures across turns
-            raw_parts = _get(m, "parts") or _get(m, "gemini_parts")
-            if isinstance(raw_parts, list) and raw_parts:
-                gemini_messages.append({"role": "model", "parts": raw_parts})
-                continue
-            parts = []
-            if content:
-                parts.append({"text": content})
-            for tc in _get(m, "tool_calls", []):
-                fn = _get(tc, "function", {})
-                arguments = _get(fn, "arguments", "")
-                try:
-                    arguments = json.loads(arguments) if arguments else {}
-                except json.JSONDecodeError:
-                    arguments = {}
-                parts.append(
-                    {
-                        "function_call": {
-                            "name": _get(fn, "name", ""),
-                            "args": arguments,
-                            "id": _get(tc, "id", ""),
-                        }
-                    }
-                )
-            gemini_messages.append({"role": "model", "parts": parts})
-        elif role == "tool":
-            # Build a FunctionResponse payload per google-genai expectations
-            # response must be an object with a 'content' list of parts
-            tool_name = _get(m, "name", "")
-            tool_id = _get(m, "tool_call_id", "") or _get(m, "id", "")
-            try:
-                parsed = json.loads(content)
-            except Exception:
-                parsed = content
-
-            # Gemini often expects: { name: <tool>, content: [{text: <json-or-text>}] }
-            if isinstance(parsed, dict) and "content" in parsed:
-                response_obj = parsed
-            else:
-                if isinstance(parsed, (dict, list)):
-                    txt = json.dumps(parsed, ensure_ascii=False)
-                else:
-                    txt = str(parsed)
-                response_obj = {
-                    "name": tool_name,
-                    "content": [{"text": txt}],
-                }
-
-            gemini_messages.append(
-                {
-                    "role": "user",
-                    "parts": [
-                        {
-                            "function_response": {
-                                "name": tool_name,
-                                "id": tool_id,
-                                "response": response_obj,
-                            }
-                        }
-                    ],
-                }
-            )
-    return system_instruction, gemini_messages
-
-
-_ALLOWED_SCHEMA_KEYS = {
-    "type",
-    "format",
-    "description",
-    "enum",
-    "properties",
-    "required",
-    "items",
+_FINISH_REASON_MAP = {
+    "FINISH_REASON_STOP": "stop",
+    "FINISH_REASON_MAX_TOKENS": "length",
+    "FINISH_REASON_SAFETY": "safety",
+    "FINISH_REASON_RECITATION": "content_filter",
+    "FINISH_REASON_TOOL_CALL": "tool_calls",
 }
 
 
-def _sanitize_schema(schema):
-    if isinstance(schema, dict):
-        cleaned = {}
-        for k, v in schema.items():
-            if k not in _ALLOWED_SCHEMA_KEYS:
-                continue
-            if k == "properties" and isinstance(v, dict):
-                props = {}
-                for pk, pv in v.items():
-                    sanitized = _sanitize_schema(pv)
-                    if sanitized:
-                        props[pk] = sanitized
-                if props:
-                    cleaned["properties"] = props
-                continue
-            if k == "items":
-                sanitized = _sanitize_schema(v)
-                if sanitized:
-                    cleaned["items"] = sanitized
-                continue
-            if k == "required" and isinstance(v, list):
-                cleaned["required"] = list(v)
-                continue
-            sanitized = _sanitize_schema(v)
-            if sanitized is not None:
-                cleaned[k] = sanitized
-        if "required" in cleaned:
-            if "properties" in cleaned:
-                cleaned["required"] = [r for r in cleaned["required"] if r in cleaned["properties"]]
-                if not cleaned["required"]:
-                    cleaned.pop("required")
-            else:
-                cleaned.pop("required")
-        return cleaned or None
-    if isinstance(schema, list):
-        sanitized_list = []
-        for v in schema:
-            sanitized = _sanitize_schema(v)
-            if sanitized is not None:
-                sanitized_list.append(sanitized)
-        return sanitized_list or None
-    return schema
-
-
-def _to_serializable(value):
+def _to_plain(value: Any) -> Any:
     if isinstance(value, dict):
-        return {k: _to_serializable(v) for k, v in value.items()}
+        return {k: _to_plain(v) for k, v in value.items()}
     if isinstance(value, list):
-        return [_to_serializable(v) for v in value]
+        return [_to_plain(v) for v in value]
+    if isinstance(value, SimpleNamespace):
+        return {k: _to_plain(v) for k, v in vars(value).items()}
     return value
 
 
-def _convert_tools(tools):
-    """Convert our tool schema to Gemini `tools` list.
-
-    Supports function tools and allows callers to pass native Gemini tools
-    (e.g., {"google_search": {}}, {"code_execution": {}}, {"url_context": {}})
-    alongside function declarations.
-    """
-    function_decls = []
-    for t in tools or []:
-        # Function tools (Chat Completions or Responses style)
-        if _get(t, "type") != "function":
-            continue
-        # Accept both Chat Completions-style ({type:function, function:{...}})
-        # and Responses-style ({type:function, name:"...", parameters:{...}})
-        fn = _get(t, "function")
-        if fn is not None:
-            name = _get(fn, "name", "")
-            desc = _get(fn, "description")
-            params = _get(fn, "parameters")
-        else:
-            name = _get(t, "name", "")
-            desc = _get(t, "description")
-            params = _get(t, "parameters")
-        if params:
-            params = _sanitize_schema(params)
+def _safe_json(value: Any) -> Any:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return {}
         try:
-            function_decls.append(
-                types.FunctionDeclaration(
-                    name=name,
-                    description=desc,
-                    parameters=params,
+            return json.loads(stripped)
+        except Exception:
+            return stripped
+    return value
+
+
+def _convert_tools(tools_spec: Iterable[Any] | None) -> list[types.Tool] | None:
+    if not tools_spec:
+        return None
+
+    declarations: list[types.FunctionDeclaration] = []
+    for tool in tools_spec:
+        data = _to_plain(tool)
+        if data.get("type") != "function":
+            continue
+        fn = data.get("function") or {}
+        name = fn.get("name")
+        if not name:
+            continue
+        declarations.append(
+            types.FunctionDeclaration(
+                name=name,
+                description=fn.get("description"),
+                parameters=fn.get("parameters"),
+            )
+        )
+
+    if not declarations:
+        return None
+
+    return [types.Tool(function_declarations=declarations)]
+
+
+def _as_text_part(text: str) -> types.Part:
+    return types.Part.from_text(text=text)
+
+
+def _convert_messages(query: Any) -> tuple[str | None, list[types.Content]]:
+    if isinstance(query, str):
+        query = [{"role": "user", "content": query}]
+
+    system_lines: list[str] = []
+    contents: list[types.Content] = []
+
+    for raw in query or []:
+        message = _to_plain(raw)
+        role = (message.get("role") or "").lower()
+
+        if role == "system":
+            content = message.get("content")
+            if content:
+                system_lines.append(str(content))
+            continue
+
+        if role == "tool":
+            name = message.get("name") or message.get("tool_call_id") or ""
+            payload = _safe_json(message.get("content"))
+            if not isinstance(payload, (dict, list)):
+                payload = {"result": payload}
+            contents.append(
+                types.Content(
+                    role="tool",
+                    parts=[
+                        types.Part.from_function_response(
+                            name=name,
+                            response=_to_plain(payload),
+                        )
+                    ],
                 )
             )
-        except Exception:
-            # Fallback simple dict; the client may coerce this as needed
-            function_decls.append({
-                "name": name,
-                "description": desc,
-                "parameters": params,
-            })
-    if function_decls:
-        return [types.Tool(function_declarations=function_decls)]
-    return None
+            continue
+
+        if role == "assistant":
+            parts: list[types.Part] = []
+            for part in message.get("parts") or message.get("gemini_parts") or []:
+                part = _to_plain(part)
+                if "text" in part:
+                    parts.append(_as_text_part(str(part["text"])))
+                elif "function_call" in part:
+                    fc = _to_plain(part["function_call"])
+                    args = _safe_json(fc.get("args"))
+                    if not isinstance(args, dict):
+                        args = {}
+                    parts.append(
+                        types.Part.from_function_call(
+                            name=fc.get("name", ""),
+                            args=_to_plain(args),
+                        )
+                    )
+            text = message.get("content")
+            if isinstance(text, str) and text:
+                parts.append(_as_text_part(text))
+            for tool_call in message.get("tool_calls") or []:
+                call = _to_plain(tool_call)
+                fn = _to_plain(call.get("function") or {})
+                args = _safe_json(fn.get("arguments"))
+                if not isinstance(args, dict):
+                    args = {}
+                parts.append(
+                    types.Part.from_function_call(
+                        name=fn.get("name", ""),
+                        args=_to_plain(args),
+                    )
+                )
+            if parts:
+                contents.append(types.Content(role="model", parts=parts))
+            continue
+
+        parts: list[types.Part] = []
+        for part in message.get("parts") or []:
+            part = _to_plain(part)
+            if isinstance(part, dict) and "text" in part:
+                parts.append(_as_text_part(str(part["text"])))
+            else:
+                parts.append(_as_text_part(str(part)))
+        if not parts:
+            content = message.get("content")
+            if isinstance(content, list):
+                for item in content:
+                    parts.append(_as_text_part(str(item)))
+            elif content is not None:
+                parts.append(_as_text_part(str(content)))
+        if parts:
+            contents.append(types.Content(role="user", parts=parts))
+
+    system_instruction = "\n".join(system_lines) if system_lines else None
+    return system_instruction, contents
+
+
+def _convert_finish_reason(reason: Any, has_tool_calls: bool) -> str:
+    if reason is None:
+        return "tool_calls" if has_tool_calls else "stop"
+    label = str(getattr(reason, "name", reason)).upper()
+    if has_tool_calls and label in {"FINISH_REASON_STOP", "FINISH_REASON_UNSPECIFIED"}:
+        return "tool_calls"
+    return _FINISH_REASON_MAP.get(label, "tool_calls" if has_tool_calls else "stop")
+
+
+class _ResponseBuilder:
+    def __init__(self) -> None:
+        self._text = ""
+        self._tool_calls: dict[str, SimpleNamespace] = {}
+        self._order: list[str] = []
+
+    @property
+    def content(self) -> str:
+        return self._text
+
+    def add_text(self, text: str) -> str:
+        if not isinstance(text, str) or not text:
+            return ""
+
+        previous = self._text
+        if text.startswith(previous):
+            delta = text[len(previous):]
+            if not delta:
+                return ""
+            self._text = previous + delta
+            return delta
+
+        self._text = text
+        return text
+
+    def add_tool_call(self, name: Any, args: Any, call_id: Any) -> tuple[SimpleNamespace, str, str]:
+        call_id_str = str(call_id) if call_id else f"tool_call_{len(self._order)}"
+        if call_id_str in self._tool_calls:
+            call = self._tool_calls[call_id_str]
+        else:
+            call = SimpleNamespace(
+                index=len(self._order),
+                id=call_id_str,
+                type="function",
+                function=SimpleNamespace(name="", arguments=""),
+            )
+            self._tool_calls[call_id_str] = call
+            self._order.append(call_id_str)
+
+        name_delta = ""
+        args_delta = ""
+
+        if isinstance(name, str) and name:
+            previous = call.function.name
+            call.function.name = name
+            if name.startswith(previous):
+                name_delta = name[len(previous):]
+            else:
+                name_delta = name
+
+        if args is not None:
+            plain_args = _to_plain(args)
+            if isinstance(plain_args, str):
+                serialized = plain_args
+            else:
+                try:
+                    serialized = json.dumps(plain_args, ensure_ascii=False)
+                except TypeError:
+                    serialized = json.dumps(plain_args, ensure_ascii=False, default=str)
+            previous = call.function.arguments
+            call.function.arguments = serialized
+            if serialized.startswith(previous):
+                args_delta = serialized[len(previous):]
+            else:
+                args_delta = serialized
+
+        return call, name_delta, args_delta
+
+    def has_tool_calls(self) -> bool:
+        return bool(self._order)
+
+    def build_message(self) -> SimpleNamespace:
+        tool_calls: list[SimpleNamespace] = []
+        for call_pos, call_id in enumerate(self._order):
+            call = self._tool_calls[call_id]
+            index = getattr(call, "index", call_pos)
+            tool_calls.append(
+                SimpleNamespace(
+                    index=index,
+                    id=call.id,
+                    type=call.type,
+                    function=SimpleNamespace(
+                        name=call.function.name,
+                        arguments=call.function.arguments,
+                    ),
+                )
+            )
+        return SimpleNamespace(
+            content=self._text,
+            tool_calls=tool_calls,
+        )
 
 
 class Gemini(LanguageModel):
@@ -242,412 +326,194 @@ class Gemini(LanguageModel):
                 .format(api_provider="Google Gemini")
             )
 
-        self.client = genai.Client(api_key=api_key)
-        # Cancellation primitives
-        import threading as _thr
-        self._cancel_lock = _thr.Lock()
-        self._cancel_ev: _thr.Event | None = None
-        self._active_stream = None
-
         proxy = gepetto.config.get_config("Gepetto", "PROXY")
+        http_options = None
         if proxy:
-            print(
-                _(
-                    "Proxy configuration for Gemini via google-genai library might require manual setup of HTTPS_PROXY environment variable."
-                )
+            http_options = types.HttpOptions(
+                client_args={"proxy": proxy},
+                async_client_args={"proxy": proxy},
             )
+
+        self.client = genai.Client(api_key=api_key, http_options=http_options)
 
     def __str__(self):
         return self.model_name
 
-    def query_model(self, query, cb, stream=False, additional_model_options=None):
-        if additional_model_options is None:
-            additional_model_options = {}
+    def _prepare_call_kwargs(
+        self,
+        query: Any,
+        additional_model_options: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        options = dict(additional_model_options or {})
+        system_instruction, contents = _convert_messages(query)
+        if not contents:
+            raise ValueError("Gemini requires at least one message to generate a response.")
 
-        config_kwargs = {}
-        if (
-            "response_format" in additional_model_options
-            and additional_model_options["response_format"].get("type") == "json_object"
-        ):
+        response_format = options.pop("response_format", None)
+        tools_spec = options.pop("tools", None)
+
+        tools = _convert_tools(tools_spec)
+
+        config_kwargs: dict[str, Any] = {
+            "safety_settings": list(_DEFAULT_SAFETY_SETTINGS),
+        }
+        try:
+            # Disable Gemini "thinking" stream to avoid spamming reasoning steps (for now).
+            # This needs to be in a try/except for older genai SDKs that do not support it
+            config_kwargs["thinking_config"] = types.ThinkingConfig(include_thoughts=False)
+        except:
+            pass
+        if system_instruction:
+            config_kwargs["system_instruction"] = system_instruction
+        if tools:
+            config_kwargs["tools"] = tools
+        if isinstance(response_format, dict) and response_format.get("type") == "json_object":
             config_kwargs["response_mime_type"] = "application/json"
-            del additional_model_options["response_format"]
 
-        system_instruction, messages = _convert_messages(
-            [{"role": "user", "content": query}] if isinstance(query, str) else query
-        )
+        config_override = options.pop("config", None)
+        if config_override is None:
+            config = types.GenerateContentConfig(**config_kwargs)
+        elif isinstance(config_override, dict):
+            merged = {**config_kwargs, **config_override}
+            config = types.GenerateContentConfig(**merged)
+        else:
+            config = config_override
 
-        tools = None
-        if "tools" in additional_model_options:
-            tools = _convert_tools(additional_model_options.pop("tools"))
+        call_kwargs = {
+            "model": self.model_name,
+            "contents": contents,
+            "config": config,
+        }
 
-        safety_settings = [
-            types.SafetySetting(
-                category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
-                threshold=types.HarmBlockThreshold.BLOCK_NONE,
-            ),
-            types.SafetySetting(
-                category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
-                threshold=types.HarmBlockThreshold.BLOCK_NONE,
-            ),
-            types.SafetySetting(
-                category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-                threshold=types.HarmBlockThreshold.BLOCK_NONE,
-            ),
-            types.SafetySetting(
-                category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-                threshold=types.HarmBlockThreshold.BLOCK_NONE,
-            ),
-        ]
+        return call_kwargs
 
-        # Enable Gemini "thinking" stream so we can display reasoning steps.
-        # Latest docs recommend ThinkingConfig(include_thoughts=True) for
-        # rolling, incremental summaries during generation.
-        try:
-            thinking_cfg = types.ThinkingConfig(include_thoughts=True)
-        except Exception:
-            thinking_cfg = None
+    def _emit_parts(
+        self,
+        parts: Iterable[Any],
+        builder: _ResponseBuilder,
+        stream_cb=None,
+    ) -> bool:
+        emitted = False
+        for part in parts:
+            text = getattr(part, "text", None)
+            if isinstance(text, str) and text:
+                delta = builder.add_text(text)
+                if stream_cb and delta:
+                    stream_cb(delta, None)
+                if delta:
+                    emitted = True
+                continue
 
-        # Avoid duplicate keys from additional options
-        additional_opts = dict(additional_model_options or {})
-        additional_opts.pop("tools", None)
-
-        config = types.GenerateContentConfig(
-            system_instruction=system_instruction,
-            tools=tools,
-            safety_settings=safety_settings,
-            thinking_config=thinking_cfg if thinking_cfg else None,
-            **config_kwargs,
-            **additional_opts,
-        )
-
-        try:
-            if stream:
-                response_stream = self.client.models.generate_content_stream(
-                    model=self.model_name,
-                    contents=messages,
-                    config=config,
+            function_call = getattr(part, "function_call", None)
+            if function_call:
+                call, name_delta, args_delta = builder.add_tool_call(
+                    getattr(function_call, "name", None),
+                    getattr(function_call, "args", None),
+                    getattr(function_call, "id", None),
                 )
-                # Initialize/record cancel state for this request
-                with self._cancel_lock:
-                    import threading as _thr
-                    self._cancel_ev = getattr(self, "_cancel_ev", None) or _thr.Event()
-                    self._active_stream = response_stream
-
-                # Accumulate tool calls across chunks to assign stable indices
-                tool_idx_by_id: dict[str, int] = {}
-                next_tool_index = 0
-                pending_tool_calls: list = []
-                saw_function_call = False
-                text_buf: list[str] = []
-                thought_buf: list[str] = []
-                # Preserve original SDK part objects to keep thought_signature bytes intact
-                raw_parts: list = []
-                sent_reasoning_done = False
-
-                def upsert_tool_call(fc_obj):
-                    nonlocal next_tool_index, saw_function_call
-                    saw_function_call = True
-                    fc_id = _get(fc_obj, "id", "") or f"auto_{next_tool_index}"
-                    if fc_id not in tool_idx_by_id:
-                        tool_idx_by_id[fc_id] = next_tool_index
-                        next_tool_index += 1
-                        pending_tool_calls.append(
-                            SimpleNamespace(
-                                index=tool_idx_by_id[fc_id],
-                                id=fc_id,
-                                type="function",
-                                function=SimpleNamespace(name="", arguments=""),
-                            )
-                        )
-                    idx = tool_idx_by_id[fc_id]
-                    call = next(tc for tc in pending_tool_calls if tc.index == idx)
-                    name = _get(fc_obj, "name", "") or ""
-                    args = _to_serializable(_get(fc_obj, "args", {})) or {}
-                    # Assign full values (avoid incremental duplication)
-                    call.function.name = name
-                    try:
-                        call.function.arguments = json.dumps(args)
-                    except Exception:
-                        call.function.arguments = json.dumps(_to_serializable(args) or {})
-
-                sent_final = False
-                for chunk in response_stream:
-                    # Cancellation check
-                    if getattr(self, "_cancel_ev", None) is not None and self._cancel_ev.is_set():
+                if stream_cb and (name_delta or args_delta):
+                    call_index = getattr(call, "index", None)
+                    if call_index is None:
                         try:
-                            close = getattr(response_stream, "close", None)
-                            if callable(close):
-                                close()
-                        except Exception:
-                            pass
-                        with self._cancel_lock:
-                            self._active_stream = None
-                        break
-                    parts = (
-                        chunk.candidates[0].content.parts if chunk.candidates else []
-                    )
-                    finalize_on_function_call = False
-                    for part in parts:
-                        if getattr(part, "text", None):
-                            # If this part carries Gemini thoughts, stream as reasoning summary
-                            if getattr(part, "thought", False):
-                                t = part.text or ""
-                                t = t.rstrip("\r\n")  # avoid extra blank lines at end
-                                if t:
-                                    cb({"reasoning_summary_text_delta": t}, None)
-                                    thought_buf.append(t)
-                                    # Keep the raw part with signature
-                                    raw_parts.append(part)
-                            else:
-                                # If normal text begins while we were still streaming thoughts,
-                                # close the reasoning summary first to avoid interleaving.
-                                if thought_buf and not sent_reasoning_done:
-                                    try:
-                                        cb({"reasoning_summary_done": "".join(thought_buf).rstrip("\r\n")}, None)
-                                    except Exception:
-                                        pass
-                                    sent_reasoning_done = True
-                                cb(part.text, None)
-                                text_buf.append(part.text)
-                                raw_parts.append(part)
-                        elif getattr(part, "function_call", None):
-                            upsert_tool_call(part.function_call)
-                            raw_parts.append(part)
-                            finalize_on_function_call = True
-
-                    # If the model requested a tool call, finalize immediately; many backends pause here
-                    if finalize_on_function_call and not sent_final:
-                        output = []
-                        final_text = "".join(text_buf)
-                        if final_text:
-                            output.append({
-                                "type": "output_text",
-                                "content": [{"text": final_text}],
-                            })
-                        final_thoughts = "".join(thought_buf).rstrip("\r\n")
-                        if final_thoughts and not sent_reasoning_done:
-                            try:
-                                cb({"reasoning_summary_done": final_thoughts}, None)
-                            except Exception:
-                                pass
-                            output.append({
-                                "type": "reasoning",
-                                "summary": [{"text": final_thoughts}],
-                            })
-                            sent_reasoning_done = True
-                        for tc in pending_tool_calls:
-                            output.append({
-                                "type": "tool_call",
-                                "id": tc.id,
-                                "name": getattr(tc.function, "name", ""),
-                                "arguments": getattr(tc.function, "arguments", ""),
-                            })
-                        if getattr(self, "_cancel_ev", None) is not None and self._cancel_ev.is_set():
-                            with self._cancel_lock:
-                                self._active_stream = None
-                            return
-                        cb(response=SimpleNamespace(output=output, gemini_parts=raw_parts, parts=raw_parts))
-                        sent_final = True
-                        try:
-                            close = getattr(response_stream, "close", None)
-                            if callable(close):
-                                close()
-                        except Exception:
-                            pass
-                        break
-
-                    fr = chunk.candidates[0].finish_reason if chunk.candidates else None
-                    if fr and getattr(types.FinishReason, "FINISH_REASON_UNSPECIFIED", None) is not None and fr != types.FinishReason.FINISH_REASON_UNSPECIFIED:
-                        # Build a Responses-like final object so CLI can extract tool calls
-                        output = []
-                        final_text = "".join(text_buf)
-                        if final_text:
-                            output.append({
-                                "type": "output_text",
-                                "content": [{"text": final_text}],
-                            })
-                        # Emit reasoning summary done and include final summary in the object
-                        final_thoughts = "".join(thought_buf).rstrip("\r\n")
-                        if final_thoughts:
-                            try:
-                                cb({"reasoning_summary_done": final_thoughts}, None)
-                            except Exception:
-                                pass
-                            output.append({
-                                "type": "reasoning",
-                                "summary": [{"text": final_thoughts}],
-                            })
-                        for tc in pending_tool_calls:
-                            output.append({
-                                "type": "tool_call",
-                                "id": tc.id,
-                                "name": getattr(tc.function, "name", ""),
-                                "arguments": getattr(tc.function, "arguments", ""),
-                            })
-                        # Skip delivering final output if canceled
-                        if getattr(self, "_cancel_ev", None) is not None and self._cancel_ev.is_set():
-                            with self._cancel_lock:
-                                self._active_stream = None
-                            return
-                        cb(response=SimpleNamespace(output=output, gemini_parts=raw_parts, parts=raw_parts))
-                        sent_final = True
-                # If the stream ended without an explicit finish_reason, flush what we have
-                if not sent_final and (saw_function_call or text_buf or thought_buf or pending_tool_calls):
-                    output = []
-                    final_text = "".join(text_buf)
-                    if final_text:
-                        output.append({
-                            "type": "output_text",
-                            "content": [{"text": final_text}],
-                        })
-                    final_thoughts = "".join(thought_buf).rstrip("\r\n")
-                    if final_thoughts and not sent_reasoning_done:
-                        try:
-                            cb({"reasoning_summary_done": final_thoughts}, None)
-                        except Exception:
-                            pass
-                        output.append({
-                            "type": "reasoning",
-                            "summary": [{"text": final_thoughts}],
-                        })
-                        sent_reasoning_done = True
-                    for tc in pending_tool_calls:
-                        output.append({
-                            "type": "tool_call",
-                            "id": tc.id,
-                            "name": getattr(tc.function, "name", ""),
-                            "arguments": getattr(tc.function, "arguments", ""),
-                        })
-                    # Skip delivering final output if canceled
-                    if getattr(self, "_cancel_ev", None) is not None and self._cancel_ev.is_set():
-                        with self._cancel_lock:
-                            self._active_stream = None
-                        return
-                    cb(response=SimpleNamespace(output=output, gemini_parts=raw_parts, parts=raw_parts))
-            else:
-                response = self.client.models.generate_content(
-                    model=self.model_name,
-                    contents=messages,
-                    config=config,
-                )
-
-                message = SimpleNamespace(content="", tool_calls=[])
-                final_thoughts = []
-                raw_parts: list = []
-                parts = (
-                    response.candidates[0].content.parts if response.candidates else []
-                )
-                for part in parts:
-                    if getattr(part, "text", None):
-                        if getattr(part, "thought", False):
-                            txt = (part.text or "").rstrip("\r\n")
-                            final_thoughts.append(txt)
-                            raw_parts.append(part)
-                        else:
-                            message.content += part.text
-                            raw_parts.append(part)
-                    elif getattr(part, "function_call", None):
-                        fc = part.function_call
-                        message.tool_calls.append(
-                            SimpleNamespace(
-                                id=_get(fc, "id", ""),
-                                type="function",
-                                function=SimpleNamespace(
-                                    name=_get(fc, "name", ""),
-                                    arguments=json.dumps(
-                                        _to_serializable(_get(fc, "args", {})) or {}
+                            call_index = builder._order.index(call.id)
+                        except ValueError:
+                            call_index = len(builder._order)
+                        call.index = call_index
+                    stream_cb(
+                        SimpleNamespace(
+                            tool_calls=[
+                                SimpleNamespace(
+                                    index=call_index,
+                                    id=call.id,
+                                    type=call.type,
+                                    function=SimpleNamespace(
+                                        name=name_delta,
+                                        arguments=args_delta,
                                     ),
-                                ),
-                            )
-                        )
-                        raw_parts.append(part)
+                                )
+                            ]
+                        ),
+                        None,
+                    )
+                emitted = True
 
-                if stream:
-                    # Adapt to streaming-like callbacks: emit text deltas, then final response
-                    if message.content:
-                        cb(message.content, None)
-                    if final_thoughts:
-                        joined = "".join(final_thoughts).rstrip("\r\n")
-                        cb({"reasoning_summary_done": joined}, None)
-                    output = []
-                    if message.content:
-                        output.append({
-                            "type": "output_text",
-                            "content": [{"text": message.content}],
-                        })
-                    if final_thoughts:
-                        output.append({
-                            "type": "reasoning",
-                            "summary": [{"text": "".join(final_thoughts).rstrip("\r\n")}],
-                        })
-                    for tc in message.tool_calls:
-                        output.append({
-                            "type": "tool_call",
-                            "id": tc.id,
-                            "name": getattr(tc.function, "name", ""),
-                            "arguments": getattr(tc.function, "arguments", ""),
-                        })
-                    cb(response=SimpleNamespace(output=output, gemini_parts=raw_parts, parts=raw_parts))
-                else:
-                    # Non-streaming: deliver a final Responses-like object directly
-                    output = []
-                    if message.content:
-                        output.append({
-                            "type": "output_text",
-                            "content": [{"text": message.content}],
-                        })
-                    if final_thoughts:
-                        output.append({
-                            "type": "reasoning",
-                            "summary": [{"text": "".join(final_thoughts).rstrip("\r\n")}],
-                        })
-                    for tc in message.tool_calls:
-                        output.append({
-                            "type": "tool_call",
-                            "id": tc.id,
-                            "name": getattr(tc.function, "name", ""),
-                            "arguments": getattr(tc.function, "arguments", ""),
-                        })
-                    cb(response=SimpleNamespace(output=output, gemini_parts=raw_parts, parts=raw_parts))
+        return emitted
 
-        except Exception as e:
-            # Suppress network/stream errors if the request was cancelled
-            try:
-                if getattr(self, "_cancel_ev", None) is not None and self._cancel_ev.is_set():
-                    with self._cancel_lock:
-                        self._active_stream = None
-                    return
-            except Exception:
-                pass
-            error_message = _(
-                "General exception encountered while running the query: {error}"
-            ).format(error=str(e))
+    def _ingest_response(self, response: Any, builder: _ResponseBuilder) -> Any:
+        finish_reason = None
+        for candidate in getattr(response, "candidates", None) or []:
+            finish_reason = getattr(candidate, "finish_reason", finish_reason)
+            content = getattr(candidate, "content", None)
+            parts = getattr(content, "parts", None) or []
+            if parts:
+                if self._emit_parts(parts, builder):
+                    continue
+
+            text = getattr(content, "text", None)
+            if isinstance(text, str) and text:
+                builder.add_text(text)
+        if not builder.content:
+            text = getattr(response, "text", None)
+            if isinstance(text, str) and text:
+                builder.add_text(text)
+        return finish_reason
+
+    def query_model(self, query, cb, stream=False, additional_model_options=None):
+        try:
+            call_kwargs = self._prepare_call_kwargs(query, additional_model_options)
+            if stream:
+                response_stream = self.client.models.generate_content_stream(**call_kwargs)
+                builder = _ResponseBuilder()
+                finish_reason = None
+                for chunk in response_stream:
+                    chunk_emitted = False
+                    for candidate in getattr(chunk, "candidates", None) or []:
+                        finish_reason = getattr(candidate, "finish_reason", finish_reason)
+                        content = getattr(candidate, "content", None)
+                        parts = getattr(content, "parts", None) or []
+                        if parts:
+                            if self._emit_parts(parts, builder, cb):
+                                chunk_emitted = True
+                            continue
+
+                        text = getattr(content, "text", None)
+                        if isinstance(text, str) and text:
+                            delta = builder.add_text(text)
+                            if delta:
+                                if cb:
+                                    cb(delta, None)
+                                chunk_emitted = True
+
+                    if not chunk_emitted:
+                        text = getattr(chunk, "text", None)
+                        if isinstance(text, str) and text:
+                            delta = builder.add_text(text)
+                            if delta:
+                                if cb:
+                                    cb(delta, None)
+                                chunk_emitted = True
+                final_reason = _convert_finish_reason(finish_reason, builder.has_tool_calls())
+                cb(None, final_reason)
+            else:
+                response = self.client.models.generate_content(**call_kwargs)
+                builder = _ResponseBuilder()
+                self._ingest_response(response, builder)
+                message = builder.build_message()
+                ida_kernwin.execute_sync(
+                    functools.partial(cb, response=message),
+                    ida_kernwin.MFF_WRITE,
+                )
+        except Exception as exc:
+            error_message = _("General exception encountered while running the query: {error}").format(error=str(exc))
             print(error_message)
 
     def query_model_async(self, query, cb, stream=False, additional_model_options=None):
-        t = threading.Thread(
-            target=self.query_model, args=[query, cb, stream, additional_model_options]
+        thread = threading.Thread(
+            target=self.query_model,
+            args=(query, cb, stream, additional_model_options),
+            daemon=True,
         )
-        t.start()
+        thread.start()
 
-
-    def cancel_current_request(self):
-        """Signal cancellation to any in‑flight streaming request."""
-        try:
-            with self._cancel_lock:
-                ev = getattr(self, "_cancel_ev", None)
-                st = getattr(self, "_active_stream", None)
-                if ev is not None:
-                    ev.set()
-                if st is not None:
-                    try:
-                        close = getattr(st, "close", None)
-                        if callable(close):
-                            close()
-                    except Exception:
-                        pass
-                self._active_stream = None
-        except Exception:
-            pass
 
 gepetto.models.model_manager.register_model(Gemini)


### PR DESCRIPTION
- Rewrote Gemini client for clearer message/tool conversion, robust streaming, and consistent finish-reason handling
- Added default safety settings and proxy support via http_options
- Supported models now include gemini-flash-latest and gemini-flash-lite-latest
- Unified response building with incremental text deltas and tool_call deltas; final non-streaming response returns content and tool_calls
- Simplified callback contract: stream text via cb(str, None) and emit final finish reason via cb(None, reason)

UI:
- Status panel log now renders Markdown with graceful fallbacks and improved auto-scroll
- Preserves log state via an internal markdown buffer
- Clearer formatting for user/assistant messages; fixed FormToPyQtWidget usage