### PR TITLE
Refactor tool responses to raise on failure

### DIFF
--- a/gepetto/ida/tools/get_disasm.py
+++ b/gepetto/ida/tools/get_disasm.py
@@ -5,7 +5,11 @@ import ida_lines
 import ida_kernwin
 
 from gepetto.ida.tools.function_utils import parse_ea
-from gepetto.ida.tools.tools import add_result_to_messages
+from gepetto.ida.tools.tools import (
+    add_result_to_messages,
+    tool_error_payload,
+    tool_result_payload,
+)
 
 
 def handle_get_disasm_tc(tc, messages):
@@ -18,16 +22,15 @@ def handle_get_disasm_tc(tc, messages):
     ea = args.get("ea")
     try:
         ea = parse_ea(ea)
-        result = get_disasm(ea)
+        data = get_disasm(ea)
+        payload = tool_result_payload(data)
     except Exception as ex:
-        result = {
-            "ok": False,
-            "error": str(ex),
-            "ea": ea if isinstance(ea, int) else None,
-            "disasm": None,
-        }
+        payload = tool_error_payload(
+            str(ex),
+            ea=ea if isinstance(ea, int) else None,
+        )
 
-    add_result_to_messages(messages, tc, result)
+    add_result_to_messages(messages, tc, payload)
 
 # -----------------------------------------------------------------------------
 
@@ -44,33 +47,10 @@ def _get_disasm_line(ea: int) -> str:
 # -----------------------------------------------------------------------------
 
 def get_disasm(ea: int) -> Dict:
-    """Return the disassembly line at a given EA.
+    """Return the disassembly line at a given EA."""
 
-    Parameters:
-        ea (int): Effective address to disassemble.
-
-    Returns:
-        dict: {
-            "ok": bool,
-            "error": str | None,
-            "ea": int,
-            "disasm": str | None,
-        }
-    """
-    result = {
-        "ok": False,
-        "error": None,
+    line = _get_disasm_line(ea)
+    return {
         "ea": ea,
-        "disasm": None,
+        "disasm": line,
     }
-
-    try:
-        line = _get_disasm_line(ea)
-        result.update(
-            ok=True,
-            disasm=line,
-        )
-    except Exception as e:
-        result["error"] = str(e)
-
-    return result

--- a/gepetto/ida/tools/get_ea.py
+++ b/gepetto/ida/tools/get_ea.py
@@ -1,7 +1,11 @@
 import json
 
 from gepetto.ida.tools.function_utils import resolve_ea
-from gepetto.ida.tools.tools import add_result_to_messages
+from gepetto.ida.tools.tools import (
+    add_result_to_messages,
+    tool_error_payload,
+    tool_result_payload,
+)
 
 
 def handle_get_ea_tc(tc, messages):
@@ -14,9 +18,9 @@ def handle_get_ea_tc(tc, messages):
 
     try:
         ea = get_ea(name)
-        payload = {"ok": True, "ea": ea}
+        payload = tool_result_payload({"ea": ea})
     except Exception as ex:
-        payload = {"ok": False, "error": str(ex)}
+        payload = tool_error_payload(str(ex), name=name)
 
     add_result_to_messages(messages, tc, payload)
 

--- a/gepetto/ida/tools/get_screen_ea.py
+++ b/gepetto/ida/tools/get_screen_ea.py
@@ -2,7 +2,11 @@ import json
 import idaapi
 import ida_kernwin
 
-from gepetto.ida.tools.tools import add_result_to_messages
+from gepetto.ida.tools.tools import (
+    add_result_to_messages,
+    tool_error_payload,
+    tool_result_payload,
+)
 
 
 def handle_get_screen_ea_tc(tc, messages):
@@ -15,12 +19,11 @@ def handle_get_screen_ea_tc(tc, messages):
     ea = get_screen_ea()
 
     if ea is not None:
-        payload = {"ok": True, "ea": ea}
+        payload = tool_result_payload({"ea": ea})
     else:
-        payload = {
-            "ok": False,
-            "error": "The cursor isn't set to a valid address. Click in a disassembly view first."
-        }
+        payload = tool_error_payload(
+            "The cursor isn't set to a valid address. Click in a disassembly view first."
+        )
 
     add_result_to_messages(messages, tc, payload)
 

--- a/gepetto/ida/tools/refresh_view.py
+++ b/gepetto/ida/tools/refresh_view.py
@@ -1,9 +1,12 @@
-+44-0
 import json
 
 import ida_kernwin
 
-from gepetto.ida.tools.tools import add_result_to_messages
+from gepetto.ida.tools.tools import (
+    add_result_to_messages,
+    tool_error_payload,
+    tool_result_payload,
+)
 
 
 def handle_refresh_view_tc(tc, messages):
@@ -12,29 +15,30 @@ def handle_refresh_view_tc(tc, messages):
     _ = json.loads(tc.function.arguments or "{}")
 
     try:
-        result = refresh_view()
+        data = refresh_view()
+        payload = tool_result_payload(data)
     except Exception as ex:
-        result = {"ok": False, "error": str(ex)}
+        payload = tool_error_payload(str(ex))
 
-    add_result_to_messages(messages, tc, result)
+    add_result_to_messages(messages, tc, payload)
 
 # -----------------------------------------------------------------------------
 
 def refresh_view() -> dict:
     """Refresh the current IDA disassembly view."""
-    out = {"ok": False}
+
+    error: dict[str, str | None] = {"message": None}
 
     def _do():
         try:
             ida_kernwin.refresh_idaview_anyway()
-            out["ok"] = True
             return 1
         except Exception as e:
-            out["error"] = str(e)
+            error["message"] = str(e)
             return 0
 
     ida_kernwin.execute_sync(_do, ida_kernwin.MFF_FAST)
 
-    if not out["ok"]:
-        raise ValueError(out.get("error", "Failed to refresh view"))
-    return out
+    if error["message"]:
+        raise RuntimeError(error["message"])
+    return {"status": "refreshed"}

--- a/gepetto/ida/tools/to_hex.py
+++ b/gepetto/ida/tools/to_hex.py
@@ -2,7 +2,11 @@
 
 import json
 
-from gepetto.ida.tools.tools import add_result_to_messages
+from gepetto.ida.tools.tools import (
+    add_result_to_messages,
+    tool_error_payload,
+    tool_result_payload,
+)
 
 
 def handle_to_hex_tc(tc, messages):
@@ -16,9 +20,9 @@ def handle_to_hex_tc(tc, messages):
 
     try:
         hex_value = to_hex(value)
-        payload = {"ok": True, "hex": hex_value}
+        payload = tool_result_payload({"hex": hex_value})
     except Exception as ex:
-        payload = {"ok": False, "error": str(ex)}
+        payload = tool_error_payload(str(ex), value=value)
 
     add_result_to_messages(messages, tc, payload)
 

--- a/gepetto/ida/tools/tools.py
+++ b/gepetto/ida/tools/tools.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, Dict
 
 import ida_kernwin
 
@@ -367,6 +368,22 @@ TOOLS = [
         },
     },
 ]
+
+
+def tool_result_payload(data: Any) -> Dict[str, Any]:
+    """Wrap successful tool results in a standard payload structure."""
+
+    return {"type": "result", "data": data}
+
+
+def tool_error_payload(message: str, **context: Any) -> Dict[str, Any]:
+    """Create an error payload with an optional context dictionary."""
+
+    error: Dict[str, Any] = {"message": message}
+    if context:
+        error["context"] = context
+    return {"type": "error", "error": error}
+
 
 def add_result_to_messages(messages, tc, result):
     tc_id = getattr(tc, "id", None) or tc.get("id")


### PR DESCRIPTION
## Summary
- add helper functions to wrap tool success and error payloads
- update all tool implementations to return raw data and raise exceptions instead of using `ok`/`error`
- refresh every handler to use the new helpers, capture exceptions, and provide consistent tool outputs

## Testing
- not run (IDA Pro environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2b51dbe748323822a2dbf58cfc16d