### PR TITLE
Add Forge LLM provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ method with the corresponding provider.
   - Qwen/Qwen2.5-VL-7B-Instruct
 - [LM Studio](https://lmstudio.ai/)
   - Any local model exposed through LM Studio (will not appear if LM Studio Developer server is not running)
+- [Forge](https://forge.tensorblock.co/)
+  - Access 200+ models from various providers through a single API key (uses `Provider/model-name` format)
 
 Adding support for additional models shouldn't be too difficult, provided whatever provider you're considering exposes
 an API similar to OpenAI's. Look into the `gepetto/models` folder for inspiration, or open an issue if you can't figure

--- a/gepetto/config.ini
+++ b/gepetto/config.ini
@@ -86,6 +86,17 @@ BASE_URL =
 # Models that will be available in the model selection menu.
 MODELS =
 
+[Forge]
+# Set your API key here, or put it in the FORGE_API_KEY environment variable.
+API_KEY =
+
+# Base URL if you want to redirect requests to a different / local model.
+# Can also be provided via the FORGE_API_BASE environment variable.
+BASE_URL =
+
+# Models that will be available in the model selection menu.
+MODELS =
+
 [SiliconFlow]
 # Set your SiliconFlow API key here
 API_KEY = 

--- a/gepetto/models/forge.py
+++ b/gepetto/models/forge.py
@@ -1,0 +1,65 @@
+import openai
+import json
+import httpx as _httpx
+
+import gepetto.config
+import gepetto.models.model_manager
+from gepetto.models.openai import GPT
+
+_ = gepetto.config._
+
+# Default models to expose through Forge
+# You can override these in config.ini
+DEFAULT_FORGE_MODELS = [
+    "OpenAI/gpt-4o-mini",
+    "OpenAI/gpt-4o",
+    "anthropic/claude-3-5-sonnet",
+    "deepseek/deepseek-chat",
+]
+
+class Forge(GPT):
+    @staticmethod
+    def get_menu_name() -> str:
+        return "Forge"
+
+    @staticmethod
+    def supported_models():
+        # Check if custom models are defined in config
+        config_models = gepetto.config.get_config("Forge", "MODELS")
+        if config_models:
+            try:
+                return json.loads(config_models)
+            except json.JSONDecodeError:
+                # If it's not valid JSON, treat it as comma-separated list
+                return [model.strip() for model in config_models.split(",")]
+        return DEFAULT_FORGE_MODELS
+
+    @staticmethod
+    def is_configured_properly() -> bool:
+        # The plugin is configured properly if the API key is provided
+        return bool(gepetto.config.get_config("Forge", "API_KEY", "FORGE_API_KEY"))
+
+    def __init__(self, model):
+        try:
+            super().__init__(model)
+        except ValueError:
+            pass  # May throw if the OpenAI API key isn't given, but we don't need it
+
+        self.model = model
+        api_key = gepetto.config.get_config("Forge", "API_KEY", "FORGE_API_KEY")
+        if not api_key:
+            raise ValueError(_("Please edit the configuration file to insert your {api_provider} API key!")
+                             .format(api_provider="Forge"))
+
+        proxy = gepetto.config.get_config("Gepetto", "PROXY")
+        base_url = gepetto.config.get_config("Forge", "BASE_URL", "FORGE_API_BASE", "https://api.forge.tensorblock.co/v1")
+
+        self.client = openai.OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            http_client=_httpx.Client(
+                proxy=proxy,
+            ) if proxy else None
+        )
+
+gepetto.models.model_manager.register_model(Forge)


### PR DESCRIPTION
## Changes

- Environment variable: FORGE_API_KEY
- Base URL: https://api.forge.tensorblock.co/v1
- Model format: Provider/model-name (e.g., OpenAI/gpt-4o)
- Non-breaking: purely additive, existing providers are untouched

## About Forge

Forge (https://github.com/TensorBlock/forge) is an open-source middleware that routes inference across 40+ upstream providers (including OpenAI, Anthropic, Gemini, DeepSeek, and OpenRouter). It is OpenAI API compatible — works with the standard OpenAI SDK by changing base_url and api_key.

## Motivation

We have seen growing interest from users who standardize on Forge for their model management and want to use it natively with ${PROJECT}. This integration aims to bridge that gap.

## Key Benefits

- Self-Hosted & Privacy-First: Forge is open-source and designed to be self-hosted, critical for users who require data sovereignty
- Future-Proofing: acts as a decoupling layer — instead of maintaining individual adapters for every new provider, Forge users can access them immediately
- Compatibility: supports established aggregators (like OpenRouter) as well as direct provider connections (BYOK)

## References

- Repo: https://github.com/TensorBlock/forge
- Docs: https://www.tensorblock.co/api-docs/overview
- Main Page: https://www.tensorblock.co/